### PR TITLE
refactor: support HTTP/3 and WebTransport in web-transport-iroh

### DIFF
--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -20,7 +20,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error_span, info, instrument};
 use web_transport_iroh::SessionError;
 
-pub const ALPN: &[u8] = b"iroh-live/1";
+pub const ALPN: &[u8] = moq_lite::lite::ALPN.as_bytes();
 
 #[stack_error(derive, add_meta, from_sources)]
 #[allow(private_interfaces)]

--- a/web-transport-iroh/src/connect.rs
+++ b/web-transport-iroh/src/connect.rs
@@ -1,0 +1,125 @@
+use web_transport_proto::{ConnectRequest, ConnectResponse, VarInt};
+
+use thiserror::Error;
+use url::Url;
+
+#[derive(Error, Debug, Clone)]
+pub enum ConnectError {
+    #[error("quic stream was closed early")]
+    UnexpectedEnd,
+
+    #[error("protocol error: {0}")]
+    ProtoError(#[from] web_transport_proto::ConnectError),
+
+    #[error("connection error")]
+    ConnectionError(#[from] iroh::endpoint::ConnectionError),
+
+    #[error("read error")]
+    ReadError(#[from] quinn::ReadError),
+
+    #[error("write error")]
+    WriteError(#[from] quinn::WriteError),
+
+    #[error("http error status: {0}")]
+    ErrorStatus(http::StatusCode),
+}
+
+pub struct Connect {
+    // The request that was sent by the client.
+    request: ConnectRequest,
+
+    // A reference to the send/recv stream, so we don't close it until dropped.
+    send: quinn::SendStream,
+
+    #[allow(dead_code)]
+    recv: quinn::RecvStream,
+}
+
+impl Connect {
+    pub async fn accept(conn: &iroh::endpoint::Connection) -> Result<Self, ConnectError> {
+        // Accept the stream that will be used to send the HTTP CONNECT request.
+        // If they try to send any other type of HTTP request, we will error out.
+        let (send, mut recv) = conn.accept_bi().await?;
+
+        let request = web_transport_proto::ConnectRequest::read(&mut recv).await?;
+        tracing::debug!("received CONNECT request: {request:?}");
+
+        // The request was successfully decoded, so we can send a response.
+        Ok(Self {
+            request,
+            send,
+            recv,
+        })
+    }
+
+    // Called by the server to send a response to the client.
+    pub async fn respond(&mut self, status: http::StatusCode) -> Result<(), ConnectError> {
+        let resp = ConnectResponse { status };
+
+        tracing::debug!("sending CONNECT response: {resp:?}");
+        resp.write(&mut self.send).await?;
+
+        Ok(())
+    }
+
+    pub async fn open(conn: &iroh::endpoint::Connection, url: Url) -> Result<Self, ConnectError> {
+        // Create a new stream that will be used to send the CONNECT frame.
+        let (mut send, mut recv) = conn.open_bi().await?;
+
+        // Create a new CONNECT request that we'll send using HTTP/3
+        let request = ConnectRequest { url };
+
+        tracing::debug!("sending CONNECT request: {request:?}");
+        request.write(&mut send).await?;
+
+        let response = web_transport_proto::ConnectResponse::read(&mut recv).await?;
+        tracing::debug!("received CONNECT response: {response:?}");
+
+        // Throw an error if we didn't get a 200 OK.
+        if response.status != http::StatusCode::OK {
+            return Err(ConnectError::ErrorStatus(response.status));
+        }
+
+        Ok(Self {
+            request,
+            send,
+            recv,
+        })
+    }
+
+    // The session ID is the stream ID of the CONNECT request.
+    pub fn session_id(&self) -> VarInt {
+        // We gotta convert from the Quinn VarInt to the (forked) WebTransport VarInt.
+        // We don't use the quinn::VarInt because that would mean a quinn dependency in web-transport-proto
+        let stream_id = quinn::VarInt::from(self.send.id());
+        VarInt::try_from(stream_id.into_inner()).unwrap()
+    }
+
+    // The URL in the CONNECT request.
+    pub fn url(&self) -> &Url {
+        &self.request.url
+    }
+
+    pub(super) fn into_inner(self) -> (quinn::SendStream, quinn::RecvStream) {
+        (self.send, self.recv)
+    }
+
+    // Keep reading from the control stream until it's closed.
+    pub(crate) async fn run_closed(self) -> (u32, String) {
+        let (_send, mut recv) = self.into_inner();
+
+        loop {
+            match web_transport_proto::Capsule::read(&mut recv).await {
+                Ok(web_transport_proto::Capsule::CloseWebTransportSession { code, reason }) => {
+                    return (code, reason);
+                }
+                Ok(web_transport_proto::Capsule::Unknown { typ, payload }) => {
+                    tracing::warn!("unknown capsule: type={typ} size={}", payload.len());
+                }
+                Err(_) => {
+                    return (1, "capsule error".to_string());
+                }
+            }
+        }
+    }
+}

--- a/web-transport-iroh/src/error.rs
+++ b/web-transport-iroh/src/error.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use n0_error::stack_error;
 use thiserror::Error;
 
+use crate::{ConnectError, SettingsError};
+
 /// An error returned when connecting to a WebTransport endpoint.
 #[stack_error(derive, from_sources)]
 #[derive(Clone)]
@@ -11,10 +13,7 @@ pub enum ClientError {
     UnexpectedEnd,
 
     #[error("failed to connect")]
-    Connect(#[error(source)] Arc<iroh::endpoint::ConnectWithOptsError>),
-
-    #[error("failed to connect")]
-    Connecting(#[error(source)] Arc<iroh::endpoint::ConnectingError>),
+    Connect(#[error(source)] Arc<iroh::endpoint::ConnectError>),
 
     #[error("connection failed")]
     Connection(#[error(source, std_err)] iroh::endpoint::ConnectionError),
@@ -25,11 +24,11 @@ pub enum ClientError {
     #[error("failed to read")]
     ReadError(#[error(source, std_err)] quinn::ReadError),
 
-    #[error("quic error")]
-    QuinnError(#[error(source, std_err)] quinn::ConnectError),
+    #[error("failed to exchange h3 settings")]
+    SettingsError(#[error(from)] SettingsError),
 
-    #[error("invalid DNS name")]
-    InvalidDnsName(String),
+    #[error("failed to exchange h3 connect")]
+    HttpError(#[error(from)] ConnectError),
 
     #[error("invalid URL")]
     InvalidUrl,
@@ -208,6 +207,12 @@ pub enum ServerError {
 
     #[error("failed to bind endpoint")]
     Bind(#[error(source)] Arc<iroh::endpoint::BindError>),
+
+    #[error("failed to exchange h3 connect")]
+    HttpError(#[error(from)] ConnectError),
+
+    #[error("failed to exchange h3 settings")]
+    SettingsError(#[error(from)] SettingsError),
 }
 
 impl web_transport_trait::Error for SessionError {

--- a/web-transport-iroh/src/lib.rs
+++ b/web-transport-iroh/src/lib.rs
@@ -25,21 +25,25 @@
 
 // External
 mod client;
+mod connect;
 mod error;
 mod recv;
 mod send;
 mod server;
 mod session;
+mod settings;
 
 pub use client::*;
+pub use connect::*;
 pub use error::*;
 pub use recv::*;
 pub use send::*;
 pub use server::*;
 pub use session::*;
+pub use settings::*;
 
 /// The HTTP/3 ALPN is required when negotiating a QUIC connection.
-pub const ALPN: &str = "iroh-moq";
+pub const ALPN_H3: &str = "h3";
 
 /// Re-export the http crate because it's in the public API.
 pub use http;

--- a/web-transport-iroh/src/settings.rs
+++ b/web-transport-iroh/src/settings.rs
@@ -1,0 +1,69 @@
+use thiserror::Error;
+use tokio::try_join;
+
+#[derive(Error, Debug, Clone)]
+pub enum SettingsError {
+    #[error("quic stream was closed early")]
+    UnexpectedEnd,
+
+    #[error("protocol error: {0}")]
+    ProtoError(#[from] web_transport_proto::SettingsError),
+
+    #[error("WebTransport is not supported")]
+    WebTransportUnsupported,
+
+    #[error("connection error")]
+    ConnectionError(#[from] iroh::endpoint::ConnectionError),
+
+    #[error("read error")]
+    ReadError(#[from] quinn::ReadError),
+
+    #[error("write error")]
+    WriteError(#[from] quinn::WriteError),
+}
+
+pub struct Settings {
+    // A reference to the send/recv stream, so we don't close it until dropped.
+    #[allow(dead_code)]
+    send: quinn::SendStream,
+
+    #[allow(dead_code)]
+    recv: quinn::RecvStream,
+}
+
+impl Settings {
+    // Establish the H3 connection.
+    pub async fn connect(conn: &iroh::endpoint::Connection) -> Result<Self, SettingsError> {
+        let recv = Self::accept(conn);
+        let send = Self::open(conn);
+
+        // Run both tasks concurrently until one errors or they both complete.
+        let (send, recv) = try_join!(send, recv)?;
+        Ok(Self { send, recv })
+    }
+
+    async fn accept(conn: &iroh::endpoint::Connection) -> Result<quinn::RecvStream, SettingsError> {
+        let mut recv = conn.accept_uni().await?;
+        let settings = web_transport_proto::Settings::read(&mut recv).await?;
+
+        tracing::debug!("received SETTINGS frame: {settings:?}");
+
+        if settings.supports_webtransport() == 0 {
+            return Err(SettingsError::WebTransportUnsupported);
+        }
+
+        Ok(recv)
+    }
+
+    async fn open(conn: &iroh::endpoint::Connection) -> Result<quinn::SendStream, SettingsError> {
+        let mut settings = web_transport_proto::Settings::default();
+        settings.enable_webtransport(1);
+
+        tracing::debug!("sending SETTINGS frame: {settings:?}");
+
+        let mut send = conn.open_uni().await?;
+        settings.write(&mut send).await?;
+
+        Ok(send)
+    }
+}


### PR DESCRIPTION
So far `web-transport-iroh` did not actually support the WebTransport protocol, but "mocked" the `web-transport` traits onto raw iroh QUIC connections.

This PR changes this by adding (optional) support for HTTP/3 connections. It's still iroh QUIC connections, but there's now a mode to exchange the HTTP3 connect and settings handshake streams, and remap the stream ids.

The main feature this allows is to send a URL with the request, which may be used for authentication against a MoQ relay.

The code is mostly ported from [`web-transport-quinn`](https://github.com/moq-dev/web-transport/tree/main/web-transport-quinn/).