### PR TITLE
deps: update iroh and moq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -825,7 +825,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -989,6 +989,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -1333,6 +1339,15 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1843,14 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "conducer"
-version = "0.3.5"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -2407,12 +2414,12 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.2",
  "fiat-crypto",
@@ -2722,7 +2729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -3214,6 +3220,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ebml-iterable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5173ac3752f08b526a6991509615e1a345b221ec3c58c7633433e8c9582312"
+dependencies = [
+ "ebml-iterable-specification",
+ "ebml-iterable-specification-derive",
+ "futures",
+]
+
+[[package]]
+name = "ebml-iterable-specification"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56467af159a98735d44231f53eaa505e919e6003266f103b99649a93f106784"
+
+[[package]]
+name = "ebml-iterable-specification-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b066b81018300fdce40f71c4db355a102699324af96fad28f25ab1b5f87de066"
+dependencies = [
+ "ebml-iterable-specification",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3239,27 +3274,27 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0-rc.11",
- "serde",
- "signature 3.0.0-rc.10",
+ "pkcs8 0.11.0",
+ "serdect",
+ "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.10.1",
  "serde",
- "sha2 0.11.0-rc.5",
- "signature 3.0.0-rc.10",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -3387,7 +3422,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -3951,6 +3986,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -4562,23 +4606,20 @@ dependencies = [
 
 [[package]]
 name = "hang"
-version = "0.15.8"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32320866e0e43ac542badd472790d8267dcca0284a344bf9a55465278ff44f3d"
 dependencies = [
- "buf-list",
  "bytes",
- "conducer",
  "derive_more",
  "hex",
  "lazy_static",
- "moq-lite",
+ "moq-net",
  "regex",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
- "tokio",
- "tracing",
  "url",
 ]
 
@@ -4635,8 +4676,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -4645,6 +4684,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hassle-rs"
@@ -4667,9 +4711,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "moq-lite",
  "moq-media",
- "n0-error",
+ "moq-net",
+ "n0-error 1.0.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4715,9 +4759,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e232f503c4cfe3f4ea6594971255ecab9f6a0080c4c8e0e17630cc701322aa4"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4744,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcca12171ce774c549f35510be702f4da00ef12ca486f0f2acb2ee96f2f5ca0f"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -4764,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7d2c928fa078e6640f26cf1b537b212e1688829c3944780025c7084e8bbbf6"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -5342,6 +5386,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5405,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.98.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9382a37668c84823e94b52eee462b3133ca7252a28de5f619a989d48b69cb30b"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "backon",
  "blake3",
@@ -5426,16 +5490,15 @@ dependencies = [
  "iroh-dns",
  "iroh-metrics",
  "iroh-relay",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 1.0.0",
  "netwatch",
  "noq",
  "noq-proto",
  "noq-udp",
  "papaya",
  "pin-project",
- "pkcs8 0.11.0-rc.11",
  "portable-atomic",
  "portmapper",
  "rand 0.10.1",
@@ -5443,7 +5506,6 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum 0.28.0",
@@ -5454,67 +5516,69 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "0.98.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738865784637830fb14204ebd3047922db83bc1816a59027af29579b9c27bd99"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.2",
  "ed25519-dalek",
  "getrandom 0.4.2",
- "n0-error",
+ "n0-error 1.0.0",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0-rc.5",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "0.98.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca474630d1e62ddef83149db6babe6a1055d901df9054349d31b22df99811b92"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
+ "arc-swap",
+ "cfg_aliases 0.2.1",
  "derive_more",
+ "hickory-resolver",
  "iroh-base",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
+ "ndk-context",
+ "portable-atomic",
+ "rand 0.10.1",
+ "rustls",
  "simple-dns",
  "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "iroh-gossip"
-version = "0.98.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b349a9ab58e3b56cf41df693bc1812add192ad70ce7c8d0dbdc7d0319d71b11f"
+checksum = "4e1dc4b05f73e7a1b9e83b531eb63c3fd671b0af3aeb13b59c546dd7ca747515"
 dependencies = [
  "blake3",
  "bytes",
- "constant_time_eq",
  "data-encoding",
  "derive_more",
- "ed25519-dalek",
  "futures-concurrency",
- "futures-lite",
- "futures-util",
  "hex",
  "indexmap 2.14.0",
  "iroh",
  "iroh-base",
  "iroh-metrics",
  "irpc",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
  "postcard",
  "rand 0.10.1",
@@ -5543,19 +5607,19 @@ dependencies = [
  "iroh-moq",
  "iroh-smol-kv",
  "iroh-tickets",
- "moq-lite",
  "moq-media",
  "moq-media-egui",
  "moq-mux",
- "n0-error",
+ "moq-net",
+ "n0-error 1.0.0",
  "n0-future",
  "n0-tracing-test",
- "n0-watcher",
+ "n0-watcher 1.0.0",
  "patchbay",
  "pollster 0.4.0",
  "postcard",
  "qr2term",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "strum 0.28.0",
  "throttled-tracing",
@@ -5578,7 +5642,7 @@ dependencies = [
  "libc",
  "moq-media",
  "moq-media-android",
- "n0-watcher",
+ "n0-watcher 0.6.1",
  "ndk",
  "ndk-context",
  "rusty-codecs",
@@ -5603,11 +5667,11 @@ dependencies = [
  "iroh-gossip",
  "iroh-live",
  "iroh-live-relay",
- "moq-lite",
  "moq-media",
  "moq-media-egui",
  "moq-mux",
- "n0-error",
+ "moq-net",
+ "n0-error 1.0.0",
  "qr2term",
  "rand 0.9.4",
  "rustls",
@@ -5633,9 +5697,9 @@ dependencies = [
  "iroh",
  "iroh-live",
  "iroh-moq",
- "moq-lite",
  "moq-media",
  "moq-native",
+ "moq-net",
  "moq-relay",
  "rand 0.9.4",
  "rustls",
@@ -5649,15 +5713,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.38.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761b45ba046134b11eb3e432fa501616b45c4bf3a30c21717578bc07aa6461dd"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
- "n0-error",
+ "n0-error 1.0.0",
  "portable-atomic",
- "postcard",
  "ryu",
  "serde",
  "tracing",
@@ -5665,9 +5728,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.4.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab063c2bfd6c3d5a33a913d4fdb5252f140db29ec67c704f20f3da7e8f92dbf"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5680,8 +5743,8 @@ name = "iroh-moq"
 version = "0.1.0"
 dependencies = [
  "iroh",
- "moq-lite",
- "n0-error",
+ "moq-net",
+ "n0-error 1.0.0",
  "n0-future",
  "tokio",
  "tokio-util",
@@ -5692,9 +5755,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.98.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa6e9a7277bfbb439739c52b57eb5f9288030983928412022b8e94a43d4d838"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
  "blake3",
  "bytes",
@@ -5711,7 +5774,7 @@ dependencies = [
  "iroh-dns",
  "iroh-metrics",
  "lru",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
  "noq",
  "noq-proto",
@@ -5738,8 +5801,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-smol-kv"
-version = "0.3.1"
-source = "git+https://github.com/n0-computer/iroh-smol-kv?branch=iroh-098#35811d095a8d9f82f66366b99f6880451bd6354f"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611e9eb3b2037e247304eb0a78527aa2cfd62b9d14c4a23b06e020697ab8f4df"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -5747,10 +5811,10 @@ dependencies = [
  "iroh",
  "iroh-gossip",
  "irpc",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
  "postcard",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rpds",
  "serde",
  "serde-big-array",
@@ -5761,27 +5825,27 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09579438a34a147dcdce8a67cdf59bd53a197bfefe71da1a8e94df9aec0583ae"
+checksum = "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54"
 dependencies = [
  "data-encoding",
  "derive_more",
  "iroh-base",
- "n0-error",
+ "n0-error 1.0.0",
  "postcard",
  "serde",
 ]
 
 [[package]]
 name = "irpc"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bacc8d71f54f16cb5ae82745cfca440ad8ecd09b4480d415b8d9dc78146432"
+checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
  "futures-util",
  "irpc-derive",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
  "noq",
  "postcard",
@@ -5794,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4651422b9d7af09fa1437a5fabbd9e074162b502a1af7f5bae8b439eaf3e049f"
+checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5990,6 +6054,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,6 +6131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0baba9496c17ae461ad833edbe1f10612044c7d2b58cdae8c5e9acb9388bfb5"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6058,6 +6153,26 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
 
 [[package]]
 name = "kurbo"
@@ -6341,11 +6456,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -6630,6 +6745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -6655,21 +6771,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "moq-lite"
-version = "0.15.15"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+name = "moq-json"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de30545123e2391b890c01f82650a868f8b4e87bc57579627c32d1a0ece51b1"
 dependencies = [
  "bytes",
- "conducer",
- "futures",
- "num_enum",
- "rand 0.9.4",
+ "json-patch",
+ "kio",
+ "moq-net",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-async",
- "web-transport-trait",
+]
+
+[[package]]
+name = "moq-loc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489094f71ebaef7f33f400947a9fd9ef1cd65b390a36b83e356920bf91866cae"
+dependencies = [
+ "bytes",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6689,17 +6812,21 @@ dependencies = [
  "fixed-resample",
  "hang",
  "image",
- "moq-lite",
  "moq-media-egui",
- "n0-error",
+ "moq-mux",
+ "moq-net",
+ "n0-error 1.0.0",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 1.0.0",
  "pollster 0.4.0",
  "postcard",
  "ringbuf",
  "rubato 1.0.1",
  "rusty-capture",
  "rusty-codecs",
+ "serde",
+ "serde_json",
+ "serde_with",
  "sonora",
  "strum 0.28.0",
  "symphonia",
@@ -6754,8 +6881,9 @@ dependencies = [
 
 [[package]]
 name = "moq-msf"
-version = "0.1.3"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccfbfb04d4fc9f7f3f31662bf12c590dbfcd79ecc4113496c07bdf497a2636d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6764,54 +6892,61 @@ dependencies = [
 
 [[package]]
 name = "moq-mux"
-version = "0.3.9"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e36e4c772895d07efda440bd0edf10d2423f9f791f59b857d9700beeb72516"
 dependencies = [
  "anyhow",
  "base64",
- "buf-list",
  "bytes",
- "conducer",
- "derive_more",
  "h264-parser",
  "hang",
+ "kio",
  "m3u8-rs",
- "moq-lite",
+ "memchr",
+ "moq-json",
+ "moq-loc",
  "moq-msf",
+ "moq-net",
  "mp4-atom",
+ "mpeg2ts",
  "num_enum",
  "reqwest 0.12.28",
  "scuffle-av1",
  "scuffle-h265",
+ "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
+ "webm-iterable",
 ]
 
 [[package]]
 name = "moq-native"
-version = "0.13.13"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f6c4ee8740b6ad911f9d05d7a617ec437450532afcb71e38b01959e193c930"
 dependencies = [
- "anyhow",
  "clap",
  "futures",
  "hex",
  "humantime",
  "humantime-serde",
- "moq-lite",
+ "moq-net",
+ "notify",
  "parking_lot",
  "quinn",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rcgen",
  "reqwest 0.12.28",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-webpki",
  "serde",
  "serde_with",
+ "socket2",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
@@ -6820,13 +6955,34 @@ dependencies = [
  "web-transport-iroh",
  "web-transport-noq",
  "web-transport-proto",
- "x509-parser",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "moq-net"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e78427132ce874978ef554d9cab419762abd115ba5c97f4bea4ea0aa523d3f"
+dependencies = [
+ "bytes",
+ "futures",
+ "kio",
+ "num_enum",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-async",
+ "web-transport-trait",
 ]
 
 [[package]]
 name = "moq-relay"
-version = "0.10.25"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63f0da535a384460bb6d9442f9a7002c4dc9a31d0ac9ae0c7f9b6585657c698"
 dependencies = [
  "anyhow",
  "axum",
@@ -6837,9 +6993,10 @@ dependencies = [
  "http-body",
  "http-cache-reqwest",
  "jsonwebtoken",
- "moq-lite",
  "moq-native",
+ "moq-net",
  "moq-token",
+ "notify",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "rustls",
@@ -6849,16 +7006,19 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "tokio-rustls",
+ "toml 1.1.2+spec-1.1.0",
  "tower-http",
+ "tower-service",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "moq-token"
-version = "0.5.17"
-source = "git+https://github.com/Frando/moq?branch=deps%2Firoh-098#ecf0dbd7efc02a6911be7f912d0fe445be625753"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94369228b8b5db87cea16e4c1ba9d36fb791f7854f73f5b7519a8eb6d3ecb1bf"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -6901,14 +7061,14 @@ dependencies = [
 
 [[package]]
 name = "mp4-atom"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8e949244bbd26ea7eb6d936af3a6a0202be68bcfc9afce700f3c9026860ff7"
+checksum = "6c6b338be0a8d66954dfb183f8469913c9c435d48885e801debde0953de74563"
 dependencies = [
  "bytes",
  "derive_more",
  "num",
- "paste",
+ "pastey 0.2.3",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -6916,13 +7076,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpeg2ts"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7541fc1a42604cbd10e8607a4e6d4b231db982888fe8065ccb191b751d6368d6"
+
+[[package]]
 name = "n0-error"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
 dependencies = [
+ "n0-error-macros 0.1.3",
+ "spez",
+]
+
+[[package]]
+name = "n0-error"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
+dependencies = [
  "anyhow",
- "n0-error-macros",
+ "n0-error-macros 1.0.0",
  "spez",
 ]
 
@@ -6931,6 +7107,17 @@ name = "n0-error-macros"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6960,15 +7147,15 @@ dependencies = [
 
 [[package]]
 name = "n0-qlog"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227d9ae7ef1e74f3e9f3e3503b06b58ff507ce754efdc29e4a44af74ad300cc3"
+checksum = "bb1c2fc610d1facce51b0bf5d8245b309c91996a933defdf7742c92ac78a58cb"
 dependencies = [
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
- "strum 0.27.2",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -6999,7 +7186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38795f7932e6e9d1c6e989270ef5b3ff24ebb910e2c9d4bed2d28d8bae3007dc"
 dependencies = [
  "derive_more",
- "n0-error",
+ "n0-error 0.1.3",
+ "n0-future",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
+dependencies = [
+ "derive_more",
+ "n0-error 1.0.0",
  "n0-future",
 ]
 
@@ -7115,20 +7313,25 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30af1a5073b82356d9317c18226826370b4288eba2f71c7e84e18bae51b3847"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2 0.6.2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation 0.3.2",
  "objc2-system-configuration",
  "once_cell",
  "plist",
@@ -7170,9 +7373,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -7209,22 +7412,23 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc0d4b4134425d9834e591b1a6f807ea365c6d941d738942215564af5f28a97"
+checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases 0.2.1",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 1.0.0",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -7418,9 +7622,9 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "noq"
-version = "0.18.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b969bd157c3bd3bab239a1a8b14f67f2033fa012770367fcbd5b42d71ae3548"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -7440,9 +7644,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "0.17.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdec6f5039d98ee5377b2f532d495a555eb664c53161b1b5780dcaeac678b60e"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -7455,10 +7659,11 @@ dependencies = [
  "lru-slab",
  "n0-qlog",
  "rand 0.10.1",
+ "rand_pcg",
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
@@ -7469,15 +7674,42 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "0.10.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91b05f4f3353290936ba1f3233518868fb4e2da99cb4c90d1f8cebb064e527"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "socket2",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -7962,6 +8194,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8098,6 +8344,16 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -8443,6 +8699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "patchbay"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,7 +8877,7 @@ dependencies = [
  "libc",
  "linux-embedded-hal",
  "moq-media",
- "n0-error",
+ "n0-error 1.0.0",
  "qrcode",
  "raw-window-handle",
  "rusty-capture",
@@ -8777,9 +9039,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -8881,20 +9143,19 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a145e62ddd9aecc9c7b1a3c84cea2a803386c7f4da7795bf9f0d50d90dc52549"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64",
  "bytes",
  "derive_more",
- "futures-lite",
- "futures-util",
  "hyper-util",
  "igd-next",
  "iroh-metrics",
  "libc",
- "n0-error",
+ "n0-error 1.0.0",
+ "n0-future",
  "netwatch",
  "num_enum",
  "rand 0.10.1",
@@ -9163,7 +9424,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -9182,7 +9443,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9281,6 +9542,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "range-alloc"
@@ -9629,7 +9899,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9929,15 +10199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9956,6 +10217,27 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys 0.8.7",
  "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys 0.8.7",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -10273,7 +10555,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
@@ -10398,9 +10680,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -10464,11 +10746,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -10483,14 +10766,24 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -10588,12 +10881,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
 
@@ -10644,9 +10937,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -10681,9 +10974,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -10752,9 +11045,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -11833,21 +12123,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -11868,15 +12143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -12463,32 +12729,21 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
 name = "vergen-gitcl"
-version = "1.0.8"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
 dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
  "time",
  "vergen",
- "vergen-lib 0.1.6",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -12881,13 +13136,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-iroh"
-version = "0.3.0"
-source = "git+https://github.com/moq-dev/web-transport?branch=deps%2Firoh-098#d5cd0558992e314cb57974d00875c2aa10b45910"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34a91cf241951b8fe02ff216fdf16fc0a52b910568053652d546ded52399f77"
 dependencies = [
  "bytes",
  "http",
  "iroh",
- "n0-error",
+ "n0-error 1.0.0",
  "n0-future",
  "tokio",
  "tracing",
@@ -12898,8 +13154,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-noq"
-version = "0.0.4"
-source = "git+https://github.com/moq-dev/web-transport?branch=deps%2Firoh-098#d5cd0558992e314cb57974d00875c2aa10b45910"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e189796e9bf7d01cbd0af81ee8dbc49f9e836a1ccd2807539b174edcf88a422b"
 dependencies = [
  "bytes",
  "futures",
@@ -12918,7 +13175,8 @@ dependencies = [
 [[package]]
 name = "web-transport-proto"
 version = "0.6.0"
-source = "git+https://github.com/moq-dev/web-transport?branch=deps%2Firoh-098#d5cd0558992e314cb57974d00875c2aa10b45910"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
 dependencies = [
  "bytes",
  "http",
@@ -12930,8 +13188,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.4"
-source = "git+https://github.com/moq-dev/web-transport?branch=deps%2Firoh-098#d5cd0558992e314cb57974d00875c2aa10b45910"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9959d7a7db997953305c49e0db5087fb495614a186d1cdfa98c40f9a194dbe5d"
 dependencies = [
  "bytes",
 ]
@@ -12962,6 +13221,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webm-iterable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fbf173b4b38f2f8bbb0082a0d4cb21f263a70811f5fccb1663c421c66d9f9"
+dependencies = [
+ "ebml-iterable",
 ]
 
 [[package]]
@@ -13548,6 +13816,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -13579,11 +13856,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -13608,6 +13902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13618,6 +13918,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13632,10 +13938,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -13650,6 +13968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13660,6 +13984,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -13674,6 +14004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13684,6 +14020,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -14447,18 +14789,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,16 @@ lto = "thin"
 
 [workspace.dependencies]
 # External
-iroh = { version = "0.98.0", default-features = false, features = ["metrics", "portmapper", "fast-apple-datapath", "tls-aws-lc-rs"] }
-iroh-gossip = "0.98.0"
-iroh-tickets = "0.5.0"
-iroh-smol-kv = { git = "https://github.com/n0-computer/iroh-smol-kv", branch = "iroh-098", default-features = false }
-hang = { git = "https://github.com/Frando/moq", branch = "deps/iroh-098" }
-moq-lite = { git = "https://github.com/Frando/moq", branch = "deps/iroh-098" }
-moq-mux = { git = "https://github.com/Frando/moq", branch = "deps/iroh-098" }
-moq-relay = { git = "https://github.com/Frando/moq", branch = "deps/iroh-098", default-features = false }
-moq-native = { git = "https://github.com/Frando/moq", branch = "deps/iroh-098", default-features = false }
-web-transport-iroh = { git = "https://github.com/moq-dev/web-transport", branch = "deps/iroh-098" }
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "portmapper", "fast-apple-datapath", "tls-aws-lc-rs"] }
+iroh-gossip = "0.101.0"
+iroh-tickets = "1.0.0"
+iroh-smol-kv = { version = "0.4.0", default-features = false }
+hang = "0.19.1"
+moq-lite = { package = "moq-net", version = "0.1.11" }
+moq-mux = "0.5.5"
+moq-relay = { version = "0.12.2", default-features = false }
+moq-native = { version = "0.17.1", default-features = false }
+web-transport-iroh = "0.6.0"
 
 # In-repo crates
 iroh-live = { path = "iroh-live", default-features = false }

--- a/demos/headless/Cargo.toml
+++ b/demos/headless/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.100"
 clap = { version = "4.5", features = ["derive"] }
 moq-media = { workspace = true, features = ["test-util", "h264", "opus"] }
 moq-lite = { workspace = true }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/demos/pi-zero/Cargo.toml
+++ b/demos/pi-zero/Cargo.toml
@@ -13,7 +13,7 @@ windowed = ["dep:winit", "dep:glutin", "dep:glutin-winit", "dep:raw-window-handl
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5", features = ["derive"] }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"

--- a/demos/pi-zero/src/watch.rs
+++ b/demos/pi-zero/src/watch.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
 use glow::HasContext;
-use iroh::Watcher;
 use iroh_live::{
     media::{format::VideoFrame, subscribe::VideoTrack},
     moq::MoqSession,
@@ -62,11 +61,11 @@ fn print_stats(
     *fps_last = Instant::now();
 
     let conn = session.conn();
-    let path_list = conn.paths().get();
+    let path_list = conn.paths();
     let rtt = path_list
         .iter()
         .find(|p| p.is_selected())
-        .and_then(|p| p.rtt())
+        .map(|p| p.rtt())
         .unwrap_or_default();
     println!(
         "fps: {fps:.0}  rtt: {}ms  decoder: {}",

--- a/iroh-live-cli/Cargo.toml
+++ b/iroh-live-cli/Cargo.toml
@@ -26,7 +26,7 @@ rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false 
 moq-media = { workspace = true }
 moq-media-egui = { workspace = true, optional = true }
 moq-mux = { workspace = true }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 qr2term = "0.3"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"

--- a/iroh-live-cli/src/import.rs
+++ b/iroh-live-cli/src/import.rs
@@ -22,15 +22,24 @@ pub async fn open_input(
     format: ImportFormat,
 ) -> anyhow::Result<Pin<Box<dyn AsyncRead + Send + 'static>>> {
     match (file, transcode) {
-        (Some(path), true) => Ok(Box::pin(transcode_file(path.clone(), format).await?)),
+        (Some(path), true) => {
+            let stream = transcode_file(path.clone(), format).await?;
+            let stream: Pin<Box<dyn AsyncRead + Send + 'static>> = Box::pin(stream);
+            Ok(stream)
+        }
         (Some(path), false) => {
             let path = path.clone();
             let file = tokio::fs::File::open(&path)
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to open {}: {e}", path.display()))?;
-            Ok(Box::pin(file))
+            let file: Pin<Box<dyn AsyncRead + Send + 'static>> = Box::pin(file);
+            Ok(file)
         }
-        (None, false) => Ok(Box::pin(tokio::io::stdin())),
+        (None, false) => {
+            let stream = tokio::io::stdin();
+            let stream: Pin<Box<dyn AsyncRead + Send + 'static>> = Box::pin(stream);
+            Ok(stream)
+        }
         (None, true) => anyhow::bail!("transcoding stdin is not supported"),
     }
 }
@@ -43,14 +52,13 @@ pub async fn init_import(
     broadcast: &mut BroadcastProducer,
     format: ImportFormat,
     input: &mut Pin<Box<dyn AsyncRead + Send + 'static>>,
-) -> anyhow::Result<moq_mux::import::StreamDecoder> {
-    let catalog = moq_mux::CatalogProducer::new(broadcast).unwrap();
+) -> anyhow::Result<moq_mux::import::Stream> {
+    let catalog = moq_mux::catalog::Producer::new(broadcast).unwrap();
     let stream_format = match format {
         ImportFormat::Fmp4 => StreamFormat::Fmp4,
         ImportFormat::Avc3 => StreamFormat::Avc3,
     };
-    let mut decoder =
-        moq_mux::import::StreamDecoder::new(broadcast.clone(), catalog, stream_format);
+    let mut decoder = moq_mux::import::Stream::new(broadcast.clone(), catalog, stream_format)?;
 
     let mut buffer = BytesMut::new();
     let mut total_read = 0usize;
@@ -85,7 +93,7 @@ pub async fn init_import(
 
 /// Continues reading media data from `input` until EOF.
 pub async fn run_import(
-    mut decoder: moq_mux::import::StreamDecoder,
+    mut decoder: moq_mux::import::Stream,
     mut input: Pin<Box<dyn AsyncRead + Send + 'static>>,
 ) -> anyhow::Result<()> {
     let mut buffer = BytesMut::new();

--- a/iroh-live-cli/src/publish.rs
+++ b/iroh-live-cli/src/publish.rs
@@ -8,7 +8,7 @@
 //! into a room, `--no-serve` disables incoming connections.
 
 use iroh_live::media::publish::LocalBroadcast;
-use moq_lite::BroadcastProducer;
+use moq_lite::{Broadcast, BroadcastProducer};
 
 use crate::{
     args::PublishArgs,
@@ -74,7 +74,7 @@ fn run_file(
     let (live, decoder, input, preview_consumer, _room) = rt.block_on(async {
         let mut input = open_input(&Some(path), args.transcode, args.format).await?;
         let live = setup_live(!args.transport.no_serve).await?;
-        let mut broadcast = BroadcastProducer::default();
+        let mut broadcast = BroadcastProducer::new(Broadcast::default());
         let preview_consumer = broadcast.consume();
         let decoder = init_import(&mut broadcast, args.format, &mut input).await?;
         let room = publish_producer(&live, broadcast, &args.transport).await?;

--- a/iroh-live-relay/src/lib.rs
+++ b/iroh-live-relay/src/lib.rs
@@ -55,8 +55,23 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
     client_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
 
     let iroh_secret = relay.iroh_secret_key()?;
+    // Register the MoQ ALPNs so the endpoint accepts iroh-native MoQ clients
+    // (e.g. the `irl` CLI and `subscribe_test`). Mirrors the ALPN set that
+    // `moq_native::iroh::EndpointConfig::bind` registers: every MoQ-lite/IETF
+    // version plus the WebTransport-over-HTTP/3 ALPN. Without this the endpoint
+    // rejects MoQ connections with "peer doesn't support any known protocol".
+    let mut alpns: Vec<Vec<u8>> = moq_native::moq_net::ALPNS
+        .iter()
+        .map(|alpn| alpn.as_bytes().to_vec())
+        .collect();
+    alpns.push(
+        moq_native::iroh::web_transport_iroh::ALPN_H3
+            .as_bytes()
+            .to_vec(),
+    );
     let iroh_endpoint = iroh::Endpoint::builder(presets::N0)
         .secret_key(iroh_secret)
+        .alpns(alpns)
         .bind()
         .await?;
 

--- a/iroh-live-relay/src/lib.rs
+++ b/iroh-live-relay/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 use axum::{extract::State, response::IntoResponse, routing::get};
 use clap::Args;
 use include_dir::{Dir, include_dir};
+use iroh::{SecretKey, endpoint::presets};
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, Connection, PublicConfig, PublicDetailed};
 use tower_http::cors::{Any, CorsLayer};
 use tracing::debug;
@@ -53,22 +54,21 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
     let mut client_config = moq_native::ClientConfig::default();
     client_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
 
-    let mut iroh_config = moq_native::IrohEndpointConfig::default();
-    iroh_config.enabled = Some(true);
-    iroh_config.secret = Some(relay.iroh_secret_path_str());
+    let iroh_secret = relay.iroh_secret_key()?;
+    let iroh_endpoint = iroh::Endpoint::builder(presets::N0)
+        .secret_key(iroh_secret)
+        .bind()
+        .await?;
 
     let server = server_config.init()?;
     let client = client_config.init()?;
-    let iroh = iroh_config.bind().await?;
     let (mut server, client) = (
-        server.with_iroh(iroh.clone()),
-        client.with_iroh(iroh.clone()),
+        server.with_iroh(Some(iroh_endpoint.clone())),
+        client.with_iroh(Some(iroh_endpoint.clone())),
     );
 
-    if let Some(ref iroh_ep) = iroh {
-        tracing::info!(endpoint_id = %iroh_ep.id(), "iroh endpoint bound");
-        println!("iroh endpoint: {}", iroh_ep.id());
-    }
+    tracing::info!(endpoint_id = %iroh_endpoint.id(), "iroh endpoint bound");
+    println!("iroh endpoint: {}", iroh_endpoint.id());
 
     let tls_info = server.tls_info();
 
@@ -82,18 +82,16 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
     }));
     let auth = auth_config.init().await?;
 
-    let cluster = Cluster::new(ClusterConfig::default(), client);
+    let cluster = Cluster::new(ClusterConfig::default()).with_client(client);
     let cluster_handle = cluster.clone();
     tokio::spawn(async move {
         cluster_handle.run().await.expect("cluster failed");
     });
 
-    let pull_state = if iroh.is_some() {
+    let pull_state = {
         let pull_ep = iroh::Endpoint::bind(iroh::endpoint::presets::N0).await?;
         let pull_live = iroh_live::Live::new(pull_ep);
         Some(Arc::new(pull::PullState::new(pull_live, cluster.clone())))
-    } else {
-        None
     };
 
     let http_state = Arc::new(HttpState {
@@ -136,9 +134,7 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
             .expect("http server failed");
     });
 
-    if let Some(ref iroh_ep) = iroh {
-        tracing::info!(iroh_addr = %iroh_ep.id(), "relay ready");
-    }
+    tracing::info!(iroh_addr = %iroh_endpoint.id(), "relay ready");
 
     let mut conn_id = 0u64;
     while let Some(request) = server.accept().await {
@@ -204,13 +200,22 @@ impl RelayServer {
         self.data_dir.join("iroh_secret_key")
     }
 
-    fn iroh_secret_path_str(&self) -> String {
-        self.iroh_secret_key_path().to_string_lossy().into_owned()
+    fn iroh_secret_key(&self) -> anyhow::Result<iroh::SecretKey> {
+        let path = self.iroh_secret_key_path();
+        if let Ok(true) = std::fs::exists(&path) {
+            let key = std::fs::read(&path)?;
+            let key = SecretKey::from_bytes((&key[..]).try_into()?);
+            Ok(key)
+        } else {
+            let key = SecretKey::generate();
+            std::fs::write(path, &key.to_bytes())?;
+            Ok(key)
+        }
     }
 }
 
 struct HttpState {
-    tls_info: Arc<RwLock<moq_native::ServerTlsInfo>>,
+    tls_info: Arc<RwLock<moq_native::tls::Info>>,
 }
 
 fn extract_name_from_url(request: &moq_native::Request) -> Option<String> {

--- a/iroh-live-relay/src/lib.rs
+++ b/iroh-live-relay/src/lib.rs
@@ -208,7 +208,7 @@ impl RelayServer {
             Ok(key)
         } else {
             let key = SecretKey::generate();
-            std::fs::write(path, &key.to_bytes())?;
+            std::fs::write(path, key.to_bytes())?;
             Ok(key)
         }
     }

--- a/iroh-live-relay/src/pull.rs
+++ b/iroh-live-relay/src/pull.rs
@@ -51,8 +51,9 @@ impl PullState {
         // Fast path: broadcast already exists in the cluster.
         if self
             .cluster
-            .primary
-            .consume_broadcast(&local_name)
+            .origin
+            .consume()
+            .get_broadcast(&local_name)
             .is_some()
         {
             tracing::debug!(
@@ -85,8 +86,9 @@ impl PullState {
                 // appeared in the cluster (success) or not (failure).
                 if self
                     .cluster
-                    .primary
-                    .consume_broadcast(&local_name)
+                    .origin
+                    .consume()
+                    .get_broadcast(&local_name)
                     .is_some()
                 {
                     Ok(local_name)
@@ -128,7 +130,7 @@ impl PullState {
             .await
             .map_err(|e| anyhow::anyhow!("failed to subscribe to broadcast: {e}"))?;
 
-        self.cluster.primary.publish_broadcast(local_name, consumer);
+        self.cluster.origin.publish_broadcast(local_name, consumer);
 
         tracing::info!(
             local_name = %local_name,

--- a/iroh-live-relay/tests/relay_bridge.rs
+++ b/iroh-live-relay/tests/relay_bridge.rs
@@ -127,7 +127,7 @@ async fn noq_publish_noq_subscribe() {
     let relay = TestRelay::start().await;
 
     // Publisher
-    let pub_origin = Origin { id: 0 }.produce();
+    let pub_origin = Origin::random().produce();
     let mut broadcast = pub_origin.create_broadcast("test").expect("create bc");
     let mut track = broadcast.create_track(Track::new("video")).expect("track");
     let mut group = track.append_group().expect("group");
@@ -148,7 +148,7 @@ async fn noq_publish_noq_subscribe() {
         .expect("connect");
 
     // Subscriber
-    let sub_origin = Origin { id: 0 }.produce();
+    let sub_origin = Origin::random().produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
@@ -271,7 +271,7 @@ async fn noq_publish_iroh_subscribe() {
 
     // ── Publisher (noq, simulating browser) ──
     // Publish a broadcast with a hang-compatible catalog and video track.
-    let pub_origin = Origin { id: 0 }.produce();
+    let pub_origin = Origin::random().produce();
     let mut broadcast = pub_origin.create_broadcast("browser-stream").expect("bc");
 
     // hang catalog format: renditions keyed by track name
@@ -439,7 +439,7 @@ async fn pull_remote_broadcast_via_ticket() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // ── Subscriber (noq, simulating browser) ──
-    let sub_origin = Origin { id: 0 }.produce();
+    let sub_origin = Origin::random().produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
@@ -533,7 +533,7 @@ async fn iroh_publish_noq_subscribe() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Subscriber (noq)
-    let sub_origin = Origin { id: 0 }.produce();
+    let sub_origin = Origin::random().produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);

--- a/iroh-live-relay/tests/relay_bridge.rs
+++ b/iroh-live-relay/tests/relay_bridge.rs
@@ -12,7 +12,7 @@ use std::{sync::OnceLock, time::Duration};
 
 use iroh::address_lookup::MemoryLookup;
 use moq_media::publish::VideoInput;
-use moq_native::moq_lite::{Origin, Track};
+use moq_native::moq_net::{Origin, Track};
 use moq_relay::{PublicConfig, PublicDetailed};
 use serial_test::serial;
 
@@ -47,7 +47,7 @@ impl TestRelay {
         // Build the relay's iroh endpoint with Minimal preset + MemoryLookup
         // instead of IrohEndpointConfig (which uses presets::N0 and real DNS
         // discovery). This makes tests reliable in CI without network access.
-        let mut alpns: Vec<Vec<u8>> = moq_native::moq_lite::ALPNS
+        let mut alpns: Vec<Vec<u8>> = moq_native::moq_net::ALPNS
             .iter()
             .map(|alpn| alpn.as_bytes().to_vec())
             .collect();
@@ -83,7 +83,8 @@ impl TestRelay {
         }));
         let auth = auth_config.init().await.expect("init auth");
 
-        let cluster = moq_relay::Cluster::new(moq_relay::ClusterConfig::default(), client);
+        let cluster =
+            moq_relay::Cluster::new(moq_relay::ClusterConfig::default()).with_client(client);
         let cluster_handle = cluster.clone();
         tokio::spawn(async move {
             cluster_handle.run().await.expect("cluster failed");
@@ -126,7 +127,7 @@ async fn noq_publish_noq_subscribe() {
     let relay = TestRelay::start().await;
 
     // Publisher
-    let pub_origin = Origin::produce();
+    let pub_origin = Origin { id: 0 }.produce();
     let mut broadcast = pub_origin.create_broadcast("test").expect("create bc");
     let mut track = broadcast.create_track(Track::new("video")).expect("track");
     let mut group = track.append_group().expect("group");
@@ -147,7 +148,7 @@ async fn noq_publish_noq_subscribe() {
         .expect("connect");
 
     // Subscriber
-    let sub_origin = Origin::produce();
+    let sub_origin = Origin { id: 0 }.produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
@@ -169,7 +170,7 @@ async fn noq_publish_noq_subscribe() {
     assert_eq!(path.as_str(), "test");
     let bc = bc.expect("announce");
     let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("sub");
-    let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group_ordered())
+    let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
         .await
         .expect("timeout")
         .expect("err")
@@ -270,7 +271,7 @@ async fn noq_publish_iroh_subscribe() {
 
     // ── Publisher (noq, simulating browser) ──
     // Publish a broadcast with a hang-compatible catalog and video track.
-    let pub_origin = Origin::produce();
+    let pub_origin = Origin { id: 0 }.produce();
     let mut broadcast = pub_origin.create_broadcast("browser-stream").expect("bc");
 
     // hang catalog format: renditions keyed by track name
@@ -432,13 +433,13 @@ async fn pull_remote_broadcast_via_ticket() {
     let local_name = ticket.to_string();
     relay
         .cluster
-        .primary
+        .origin
         .publish_broadcast(&local_name, consumer);
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // ── Subscriber (noq, simulating browser) ──
-    let sub_origin = Origin::produce();
+    let sub_origin = Origin { id: 0 }.produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
@@ -469,7 +470,7 @@ async fn pull_remote_broadcast_via_ticket() {
     let mut catalog_track = bc
         .subscribe_track(&Track::new("catalog.json"))
         .expect("catalog sub");
-    let mut group = tokio::time::timeout(TIMEOUT, catalog_track.next_group_ordered())
+    let mut group = tokio::time::timeout(TIMEOUT, catalog_track.next_group())
         .await
         .expect("catalog group timeout")
         .expect("catalog group err")
@@ -532,7 +533,7 @@ async fn iroh_publish_noq_subscribe() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Subscriber (noq)
-    let sub_origin = Origin::produce();
+    let sub_origin = Origin { id: 0 }.produce();
     let mut announcements = sub_origin.consume();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);

--- a/iroh-live/Cargo.toml
+++ b/iroh-live/Cargo.toml
@@ -18,11 +18,11 @@ iroh-moq = { workspace = true }
 iroh-tickets = { workspace = true }
 moq-lite = { workspace = true }
 moq-media = { workspace = true }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 n0-future = "0.3.1"
-n0-watcher = "0.6.0"
+n0-watcher = "1"
 postcard = "1.1.3"
-rand = "0.9"
+rand = "0.10"
 serde = { version = "1.0.228", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 tokio = { version = "1.48.0", features = ["sync"] }

--- a/iroh-live/examples/watch-wgpu.rs
+++ b/iroh-live/examples/watch-wgpu.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use clap::Parser;
-use iroh::{Endpoint, EndpointId, Watcher};
+use iroh::{Endpoint, EndpointId};
 use iroh_live::{
     Live,
     media::{
@@ -232,11 +232,11 @@ impl WgpuApp {
             self.fps_last_update = Instant::now();
             // Print stats to stdout.
             let conn = self.session.conn();
-            let path_list = conn.paths().get();
+            let path_list = conn.paths();
             let rtt = path_list
                 .iter()
                 .find(|p| p.is_selected())
-                .and_then(|p| p.rtt())
+                .map(|p| p.rtt())
                 .unwrap_or_default();
             println!(
                 "fps: {:.0}  rtt: {}ms  decoder: {}",

--- a/iroh-live/src/rooms.rs
+++ b/iroh-live/src/rooms.rs
@@ -613,7 +613,7 @@ mod ticket {
     /// Contains the gossip topic ID and optional bootstrap peer IDs.
     /// Serializes to a compact string via the `iroh_tickets` crate.
     #[derive(Debug, Serialize, Deserialize, Clone, derive_more::Display)]
-    #[display("{}", iroh_tickets::Ticket::serialize(self))]
+    #[display("{}", iroh_tickets::Ticket::encode_string(self))]
     pub struct RoomTicket {
         /// Peers to contact initially for gossip bootstrap.
         pub bootstrap: Vec<EndpointId>,
@@ -676,18 +676,18 @@ mod ticket {
         type Err = iroh_tickets::ParseError;
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
-            iroh_tickets::Ticket::deserialize(s)
+            iroh_tickets::Ticket::decode_string(s)
         }
     }
 
     impl iroh_tickets::Ticket for RoomTicket {
         const KIND: &'static str = "room";
 
-        fn to_bytes(&self) -> Vec<u8> {
+        fn encode_bytes(&self) -> Vec<u8> {
             postcard::to_stdvec(self).expect("RoomTicket serialization is infallible")
         }
 
-        fn from_bytes(bytes: &[u8]) -> Result<Self, iroh_tickets::ParseError> {
+        fn decode_bytes(bytes: &[u8]) -> Result<Self, iroh_tickets::ParseError> {
             let ticket = postcard::from_bytes(bytes)?;
             Ok(ticket)
         }

--- a/iroh-live/src/util.rs
+++ b/iroh-live/src/util.rs
@@ -2,7 +2,6 @@ use std::{thread, time::Duration};
 
 use iroh::{SecretKey, endpoint::Connection};
 use moq_media::net::NetworkSignals;
-use n0_watcher::Watcher;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
@@ -61,17 +60,13 @@ pub fn spawn_signal_producer(
                 _ = shutdown.cancelled() => break,
             }
 
-            let paths = conn.paths().get();
+            let paths = conn.paths();
             let Some(selected) = paths.iter().find(|p| p.is_selected()) else {
                 continue;
             };
 
-            let Some(stats) = selected.stats() else {
-                continue;
-            };
-            let Some(rtt) = selected.rtt() else {
-                continue;
-            };
+            let stats = selected.stats();
+            let rtt = selected.rtt();
 
             // Delta-based loss rate.
             let total_lost = stats.lost_packets;
@@ -136,16 +131,12 @@ pub fn spawn_stats_recorder(
                 _ = shutdown.cancelled() => break,
             }
 
-            let paths = conn.paths().get();
+            let paths = conn.paths();
             let Some(selected) = paths.iter().find(|p| p.is_selected()) else {
                 continue;
             };
-            let Some(stats) = selected.stats() else {
-                continue;
-            };
-            let Some(rtt) = selected.rtt() else {
-                continue;
-            };
+            let stats = selected.stats();
+            let rtt = selected.rtt();
 
             let rtt_ms = rtt.as_secs_f64() * 1000.0;
             net.rtt_ms.record(rtt_ms);
@@ -160,7 +151,7 @@ pub fn spawn_stats_recorder(
             net.path_addr.set(format!("{:?}", selected.remote_addr()));
 
             // Path counts.
-            let active = paths.iter().filter(|p| !p.is_closed()).count();
+            let active = paths.iter().count();
             net.paths_active.record(active as f64);
 
             // Delta-based loss rate (recent interval, not session-lifetime).

--- a/iroh-moq/Cargo.toml
+++ b/iroh-moq/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 iroh = { workspace = true }
 moq-lite = { workspace = true }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 n0-future = "0.3.1"
 tokio = { version = "1.48.0", features = ["sync"] }
 tokio-util = "0.7.17"

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -274,9 +274,13 @@ impl MoqSession {
 
     /// Establishes a MoQ session as the client (initiator) over an existing WebTransport session.
     pub async fn session_connect(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        // TODO: make use of origin ids
-        let publish_prod = OriginProducer::new(Origin { id: 0 });
-        let subscribe_prod = OriginProducer::new(Origin { id: 0 });
+        // One origin id identifies this node in broadcast hop chains. Sharing it
+        // across the publish and subscribe sides lets loop detection recognize a
+        // broadcast that a peer echoes back to us. The id must be non-zero: zero
+        // is the reserved `UNKNOWN` placeholder and fails to round-trip on the wire.
+        let origin = Origin::random();
+        let publish_prod = OriginProducer::new(origin);
+        let subscribe_prod = OriginProducer::new(origin);
         let subscribe = subscribe_prod.consume();
         let client = moq_lite::Client::new()
             .with_publish(publish_prod.consume())
@@ -292,9 +296,10 @@ impl MoqSession {
 
     /// Accepts a MoQ session as the server (responder) over an existing WebTransport session.
     pub async fn session_accept(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        // TODO: make use of origin ids
-        let publish_prod = OriginProducer::new(Origin { id: 0 });
-        let subscribe_prod = OriginProducer::new(Origin { id: 0 });
+        // See `session_connect` for why both sides share one non-zero origin id.
+        let origin = Origin::random();
+        let publish_prod = OriginProducer::new(origin);
+        let subscribe_prod = OriginProducer::new(origin);
         let subscribe = subscribe_prod.consume();
         let server = moq_lite::Server::new()
             .with_publish(publish_prod.consume())
@@ -327,27 +332,10 @@ impl MoqSession {
         if let Some(reason) = self.conn().close_reason() {
             return Err(SessionError::from(reason).into());
         }
-        let consumer = self.subscribe.announced_broadcast(name).await;
-        match consumer {
+        match self.subscribe.announced_broadcast(name).await {
             None => Err(e!(SubscribeError::Closed)),
             Some(consumer) => Ok(consumer),
         }
-        // if let Some(consumer) = self.subscribe.consume_broadcast(name) {
-        //     return Ok(consumer);
-        // }
-        // loop {
-        //     let res = tokio::select! {
-        //         res = self.subscribe.announced() => res,
-        //         reason = self.wt_session.closed() => {
-        //             return Err(reason.into())
-        //         }
-        //     };
-        //     let (path, consumer) = res.ok_or_else(|| e!(SubscribeError::NotAnnounced))?;
-        //     debug!("peer announced broadcast: {path}");
-        //     if path.as_str() == name {
-        //         return consumer.ok_or_else(|| e!(SubscribeError::Closed));
-        //     }
-        // }
     }
 
     /// Publishes a broadcast on this session, making it available to the remote peer.

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -27,9 +27,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error_span, field, info, instrument};
 use web_transport_iroh::SessionError;
 
-// TODO: Use export from moq_lite after next update
 /// The ALPN protocol identifier for MoQ-lite connections.
-pub const ALPN: &[u8] = b"moq-lite-03";
+///
+/// `moq-lite-04` is the current wire version: it carries real origin ids in
+/// announce hop chains (lite-03 sent anonymous `UNKNOWN` placeholders) and
+/// supports `AnnounceInterest.exclude_hop` for sender-side loop suppression.
+pub const ALPN: &[u8] = b"moq-lite-04";
 
 #[stack_error(derive, add_meta, from_sources)]
 #[allow(private_interfaces, reason = "trait impl uses private types")]

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -79,6 +79,7 @@ pub struct Moq {
     tx: mpsc::Sender<ActorMessage>,
     incoming_session_tx: broadcast::Sender<MoqSession>,
     shutdown_token: CancellationToken,
+    origin: Origin,
     _actor_handle: Arc<AbortOnDropHandle<()>>,
 }
 
@@ -87,7 +88,12 @@ impl Moq {
     pub fn new(endpoint: Endpoint) -> Self {
         let (tx, rx) = mpsc::channel(16);
         let (incoming_session_tx, _) = broadcast::channel(16);
-        let actor = Actor::new(endpoint, incoming_session_tx.clone());
+        // One non-zero origin id identifies this node in broadcast announce hop
+        // chains. It is created once here and shared across every session this
+        // node opens or accepts, matching the per-node identity that relays use
+        // for loop detection and shortest-path routing.
+        let origin = Origin::random();
+        let actor = Actor::new(endpoint, incoming_session_tx.clone(), origin);
         let shutdown_token = actor.shutdown_token.clone();
         let actor_task =
             spawn(async move { actor.run(rx).await }.instrument(error_span!("LiveActor")));
@@ -95,6 +101,7 @@ impl Moq {
             shutdown_token,
             tx,
             incoming_session_tx,
+            origin,
             _actor_handle: Arc::new(AbortOnDropHandle::new(actor_task)),
         }
     }
@@ -103,6 +110,7 @@ impl Moq {
     pub fn protocol_handler(&self) -> MoqProtocolHandler {
         MoqProtocolHandler {
             tx: self.tx.clone(),
+            origin: self.origin,
         }
     }
 
@@ -168,13 +176,14 @@ impl Moq {
 #[derive(Debug, Clone)]
 pub struct MoqProtocolHandler {
     tx: mpsc::Sender<ActorMessage>,
+    origin: Origin,
 }
 
 impl MoqProtocolHandler {
     async fn handle_connection(&self, connection: Connection) -> Result<(), Error> {
         info!(remote = %connection.remote_id().fmt_short(), "accepted");
         let session = web_transport_iroh::Session::raw(connection);
-        let session = MoqSession::session_accept(session).await?;
+        let session = MoqSession::session_accept(session, self.origin).await?;
         self.tx
             .send(ActorMessage::HandleSession {
                 session: Box::new(session),
@@ -267,21 +276,25 @@ impl MoqSession {
     pub async fn connect(
         endpoint: &Endpoint,
         remote_addr: impl Into<EndpointAddr>,
+        origin: Origin,
     ) -> Result<Self, Error> {
         let addr = remote_addr.into();
         tracing::Span::current().record("remote", field::display(addr.id.fmt_short()));
         let connection = endpoint.connect(addr, ALPN).await?;
         let wt_session = web_transport_iroh::Session::raw(connection);
-        Self::session_connect(wt_session).await
+        Self::session_connect(wt_session, origin).await
     }
 
     /// Establishes a MoQ session as the client (initiator) over an existing WebTransport session.
-    pub async fn session_connect(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        // One origin id identifies this node in broadcast hop chains. Sharing it
-        // across the publish and subscribe sides lets loop detection recognize a
-        // broadcast that a peer echoes back to us. The id must be non-zero: zero
-        // is the reserved `UNKNOWN` placeholder and fails to round-trip on the wire.
-        let origin = Origin::random();
+    ///
+    /// `origin` is this node's identity, stamped onto the broadcasts it announces
+    /// to the peer. The same id is used for the publish and subscribe sides so
+    /// loop detection sees one consistent hop for this node. It must be non-zero:
+    /// zero is the reserved `UNKNOWN` placeholder and is never encoded on the wire.
+    pub async fn session_connect(
+        wt_session: web_transport_iroh::Session,
+        origin: Origin,
+    ) -> Result<Self, Error> {
         let publish_prod = OriginProducer::new(origin);
         let subscribe_prod = OriginProducer::new(origin);
         let subscribe = subscribe_prod.consume();
@@ -298,9 +311,12 @@ impl MoqSession {
     }
 
     /// Accepts a MoQ session as the server (responder) over an existing WebTransport session.
-    pub async fn session_accept(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        // See `session_connect` for why both sides share one non-zero origin id.
-        let origin = Origin::random();
+    ///
+    /// See [`session_connect`](Self::session_connect) for the role of `origin`.
+    pub async fn session_accept(
+        wt_session: web_transport_iroh::Session,
+        origin: Origin,
+    ) -> Result<Self, Error> {
         let publish_prod = OriginProducer::new(origin);
         let subscribe_prod = OriginProducer::new(origin);
         let subscribe = subscribe_prod.consume();
@@ -391,6 +407,7 @@ struct Actor {
     endpoint: Endpoint,
     shutdown_token: CancellationToken,
     incoming_session_tx: broadcast::Sender<MoqSession>,
+    origin: Origin,
     publishing: HashMap<BroadcastName, BroadcastProducer>,
     publishing_closed_futs: FuturesUnordered<BoxFuture<BroadcastName>>,
     sessions: HashMap<EndpointId, MoqSession>,
@@ -403,11 +420,13 @@ impl Actor {
     pub(crate) fn new(
         endpoint: Endpoint,
         incoming_session_tx: broadcast::Sender<MoqSession>,
+        origin: Origin,
     ) -> Self {
         Self {
             endpoint,
             shutdown_token: CancellationToken::new(),
             incoming_session_tx,
+            origin,
             publishing: Default::default(),
             publishing_closed_futs: Default::default(),
             sessions: Default::default(),
@@ -539,8 +558,9 @@ impl Actor {
             }
             hash_map::Entry::Vacant(entry) => {
                 let endpoint = self.endpoint.clone();
+                let origin = self.origin;
                 self.pending_connect_tasks.spawn(async move {
-                    let res = MoqSession::connect(&endpoint, remote)
+                    let res = MoqSession::connect(&endpoint, remote, origin)
                         .await
                         .map_err(Into::into);
                     (remote_id, res)

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -15,7 +15,7 @@ use iroh::{
     endpoint::{ConnectError, Connection, ConnectionError, WriteError},
     protocol::{AcceptError, ProtocolHandler},
 };
-use moq_lite::{BroadcastConsumer, BroadcastProducer, OriginConsumer, OriginProducer};
+use moq_lite::{BroadcastConsumer, BroadcastProducer, Origin, OriginConsumer, OriginProducer};
 use n0_error::{AnyError, Result, StdResultExt, anyerr, e, stack_error};
 use n0_future::{
     FuturesUnordered, StreamExt,
@@ -274,8 +274,9 @@ impl MoqSession {
 
     /// Establishes a MoQ session as the client (initiator) over an existing WebTransport session.
     pub async fn session_connect(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        let publish_prod = OriginProducer::new();
-        let subscribe_prod = OriginProducer::new();
+        // TODO: make use of origin ids
+        let publish_prod = OriginProducer::new(Origin { id: 0 });
+        let subscribe_prod = OriginProducer::new(Origin { id: 0 });
         let subscribe = subscribe_prod.consume();
         let client = moq_lite::Client::new()
             .with_publish(publish_prod.consume())
@@ -291,8 +292,9 @@ impl MoqSession {
 
     /// Accepts a MoQ session as the server (responder) over an existing WebTransport session.
     pub async fn session_accept(wt_session: web_transport_iroh::Session) -> Result<Self, Error> {
-        let publish_prod = OriginProducer::new();
-        let subscribe_prod = OriginProducer::new();
+        // TODO: make use of origin ids
+        let publish_prod = OriginProducer::new(Origin { id: 0 });
+        let subscribe_prod = OriginProducer::new(Origin { id: 0 });
         let subscribe = subscribe_prod.consume();
         let server = moq_lite::Server::new()
             .with_publish(publish_prod.consume())
@@ -325,22 +327,27 @@ impl MoqSession {
         if let Some(reason) = self.conn().close_reason() {
             return Err(SessionError::from(reason).into());
         }
-        if let Some(consumer) = self.subscribe.consume_broadcast(name) {
-            return Ok(consumer);
+        let consumer = self.subscribe.announced_broadcast(name).await;
+        match consumer {
+            None => Err(e!(SubscribeError::Closed)),
+            Some(consumer) => Ok(consumer),
         }
-        loop {
-            let res = tokio::select! {
-                res = self.subscribe.announced() => res,
-                reason = self.wt_session.closed() => {
-                    return Err(reason.into())
-                }
-            };
-            let (path, consumer) = res.ok_or_else(|| e!(SubscribeError::NotAnnounced))?;
-            debug!("peer announced broadcast: {path}");
-            if path.as_str() == name {
-                return consumer.ok_or_else(|| e!(SubscribeError::Closed));
-            }
-        }
+        // if let Some(consumer) = self.subscribe.consume_broadcast(name) {
+        //     return Ok(consumer);
+        // }
+        // loop {
+        //     let res = tokio::select! {
+        //         res = self.subscribe.announced() => res,
+        //         reason = self.wt_session.closed() => {
+        //             return Err(reason.into())
+        //         }
+        //     };
+        //     let (path, consumer) = res.ok_or_else(|| e!(SubscribeError::NotAnnounced))?;
+        //     debug!("peer announced broadcast: {path}");
+        //     if path.as_str() == name {
+        //         return consumer.ok_or_else(|| e!(SubscribeError::Closed));
+        //     }
+        // }
     }
 
     /// Publishes a broadcast on this session, making it available to the remote peer.

--- a/moq-media/Cargo.toml
+++ b/moq-media/Cargo.toml
@@ -19,9 +19,9 @@ ringbuf = "0.4"
 hang = { workspace = true }
 image = { version = "0.25", default-features = false }
 moq-lite = { workspace = true }
-n0-error = { version = "0.1.2", features = ["anyhow"] }
+n0-error = { version = "1", features = ["anyhow"] }
 n0-future = "0.3.1"
-n0-watcher = "0.6.0"
+n0-watcher = "1"
 rusty-codecs = { workspace = true, features = ["hang"] }
 strum = { version = "0.28", features = ["derive"] }
 tokio = { version = "1.48.0", features = ["sync"] }
@@ -34,6 +34,10 @@ rubato = "1.0"
 audioadapter-buffers = "2.0"
 bytes = "1.11.0"
 throttled-tracing = "0.1.0"
+serde_with = "3.21.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+moq-mux.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cros-codecs = { version = "0.0.6", optional = true, features = ["vaapi"] }

--- a/moq-media/src/adaptive.rs
+++ b/moq-media/src/adaptive.rs
@@ -240,24 +240,16 @@ mod tests {
     use super::*;
 
     fn test_config(w: u32, h: u32, bitrate: u64) -> VideoConfig {
-        VideoConfig {
-            codec: VideoCodec::H264(H264 {
-                inline: true,
-                profile: 0x64,
-                constraints: 0,
-                level: 0x1f,
-            }),
-            coded_width: Some(w),
-            coded_height: Some(h),
-            bitrate: Some(bitrate),
-            description: None,
-            display_ratio_width: None,
-            display_ratio_height: None,
-            framerate: None,
-            optimize_for_latency: None,
-            container: Default::default(),
-            jitter: None,
-        }
+        let mut config = VideoConfig::new(VideoCodec::H264(H264 {
+            inline: true,
+            profile: 0x64,
+            constraints: 0,
+            level: 0x1f,
+        }));
+        config.coded_width = Some(w);
+        config.coded_height = Some(h);
+        config.bitrate = Some(bitrate);
+        config
     }
 
     fn test_ranked() -> Vec<RankedRendition> {

--- a/moq-media/src/catalog.rs
+++ b/moq-media/src/catalog.rs
@@ -1,13 +1,24 @@
+use hang::catalog::{Audio, Video};
 use serde::{Deserialize, Serialize};
 
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, derive_more::Deref)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Catalog {
-    #[serde(flatten)]
-    #[deref]
-    pub hang: hang::Catalog,
+    /// Video track information with multiple renditions.
+    ///
+    /// Contains a map of video track renditions that the viewer can choose from
+    /// based on their preferences (resolution, bitrate, codec, etc).
+    #[serde(default)]
+    pub video: Video,
+
+    /// Audio track information with multiple renditions.
+    ///
+    /// Contains a map of audio track renditions that the viewer can choose from
+    /// based on their preferences (codec, bitrate, language, etc).
+    #[serde(default)]
+    pub audio: Audio,
     pub chat: Option<Chat>,
     pub user: Option<User>,
 }

--- a/moq-media/src/catalog.rs
+++ b/moq-media/src/catalog.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+
+#[serde_with::serde_as]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, derive_more::Deref)]
+#[serde(default, rename_all = "camelCase")]
+pub struct Catalog {
+    #[serde(flatten)]
+    #[deref]
+    pub hang: hang::Catalog,
+    pub chat: Option<Chat>,
+    pub user: Option<User>,
+}
+
+#[serde_with::serde_as]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct Chat {
+    pub message: Option<moq_lite::Track>,
+    pub typing: Option<moq_lite::Track>,
+}
+
+#[serde_with::serde_as]
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct User {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub avatar: Option<String>,
+    pub color: Option<String>,
+}
+
+/// A catalog consumer, used to receive catalog updates and discover tracks.
+///
+/// This wraps a `moq_lite::TrackConsumer` and automatically deserializes JSON
+/// catalog data to discover available audio and video tracks in a broadcast.
+#[derive(Clone, derive_more::Debug)]
+#[debug("CatalogConsumer({})", track.name)]
+pub struct CatalogConsumer {
+    /// Access to the underlying track consumer.
+    pub track: moq_lite::TrackConsumer,
+    group: Option<moq_lite::GroupConsumer>,
+}
+
+impl CatalogConsumer {
+    /// Create a new catalog consumer from a MoQ track consumer.
+    pub fn new(track: moq_lite::TrackConsumer) -> Self {
+        Self { track, group: None }
+    }
+
+    /// Get the next catalog update.
+    ///
+    /// This method waits for the next catalog publication and returns the
+    /// catalog data. If there are no more updates, `None` is returned.
+    pub async fn next(&mut self) -> anyhow::Result<Option<Catalog>> {
+        loop {
+            tokio::select! {
+                res = self.track.next_group() => {
+                    match res? {
+                        Some(group) => {
+                            // Use the new group.
+                            self.group = Some(group);
+                        }
+                        // The track has ended, so we should return None.
+                        None => return Ok(None),
+                    }
+                },
+                Some(frame) = async { self.group.as_mut()?.read_frame().await.transpose() } => {
+                    self.group.take(); // We don't support deltas yet
+                    let catalog: Catalog = serde_json::from_slice(&frame?)?;
+                    return Ok(Some(catalog));
+                }
+            }
+        }
+    }
+
+    /// Wait until the catalog track is closed.
+    pub async fn closed(&self) -> anyhow::Result<()> {
+        Ok(self.track.closed().await?)
+    }
+}
+
+impl From<moq_lite::TrackConsumer> for CatalogConsumer {
+    fn from(inner: moq_lite::TrackConsumer) -> Self {
+        Self::new(inner)
+    }
+}

--- a/moq-media/src/catalog.rs
+++ b/moq-media/src/catalog.rs
@@ -1,29 +1,31 @@
-use hang::catalog::{Audio, Video};
+use moq_mux::catalog::hang::CatalogExt;
 use serde::{Deserialize, Serialize};
 
-#[serde_with::serde_as]
+/// The iroh-live broadcast catalog: hang's base catalog (the `video` and
+/// `audio` sections) extended with the iroh-live [`IrohLiveExt`] sections.
+///
+/// Use [`moq_mux::catalog::Producer`] to publish it and [`CatalogConsumer`] to
+/// receive updates.
+pub type Catalog = moq_mux::catalog::hang::Catalog<IrohLiveExt>;
+
+/// Receives [`Catalog`] updates and lets a subscriber discover available tracks.
+pub type CatalogConsumer = moq_mux::catalog::hang::Consumer<IrohLiveExt>;
+
+/// The iroh-live catalog extension, flattened alongside hang's `video`/`audio`.
+///
+/// Carries the chat and user sections specific to iroh-live. Extending hang's
+/// catalog through [`CatalogExt`] keeps it wire-compatible with base consumers,
+/// which ignore the extra sections.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
-pub struct Catalog {
-    /// Video track information with multiple renditions.
-    ///
-    /// Contains a map of video track renditions that the viewer can choose from
-    /// based on their preferences (resolution, bitrate, codec, etc).
-    #[serde(default)]
-    pub video: Video,
-
-    /// Audio track information with multiple renditions.
-    ///
-    /// Contains a map of audio track renditions that the viewer can choose from
-    /// based on their preferences (codec, bitrate, language, etc).
-    #[serde(default)]
-    pub audio: Audio,
+pub struct IrohLiveExt {
     pub chat: Option<Chat>,
     pub user: Option<User>,
 }
 
-#[serde_with::serde_as]
+impl CatalogExt for IrohLiveExt {}
+
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
@@ -32,7 +34,6 @@ pub struct Chat {
     pub typing: Option<moq_lite::Track>,
 }
 
-#[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
@@ -43,58 +44,32 @@ pub struct User {
     pub color: Option<String>,
 }
 
-/// A catalog consumer, used to receive catalog updates and discover tracks.
-///
-/// This wraps a `moq_lite::TrackConsumer` and automatically deserializes JSON
-/// catalog data to discover available audio and video tracks in a broadcast.
-#[derive(Clone, derive_more::Debug)]
-#[debug("CatalogConsumer({})", track.name)]
-pub struct CatalogConsumer {
-    /// Access to the underlying track consumer.
-    pub track: moq_lite::TrackConsumer,
-    group: Option<moq_lite::GroupConsumer>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl CatalogConsumer {
-    /// Create a new catalog consumer from a MoQ track consumer.
-    pub fn new(track: moq_lite::TrackConsumer) -> Self {
-        Self { track, group: None }
-    }
+    #[test]
+    fn ext_flattens_into_catalog() {
+        let mut catalog = Catalog::default();
+        catalog.ext.chat = Some(Chat {
+            message: Some(moq_lite::Track {
+                name: "chat".to_string(),
+                priority: 10,
+            }),
+            typing: None,
+        });
+        catalog.ext.user = Some(User {
+            name: Some("alice".to_string()),
+            ..Default::default()
+        });
 
-    /// Get the next catalog update.
-    ///
-    /// This method waits for the next catalog publication and returns the
-    /// catalog data. If there are no more updates, `None` is returned.
-    pub async fn next(&mut self) -> anyhow::Result<Option<Catalog>> {
-        loop {
-            tokio::select! {
-                res = self.track.next_group() => {
-                    match res? {
-                        Some(group) => {
-                            // Use the new group.
-                            self.group = Some(group);
-                        }
-                        // The track has ended, so we should return None.
-                        None => return Ok(None),
-                    }
-                },
-                Some(frame) = async { self.group.as_mut()?.read_frame().await.transpose() } => {
-                    self.group.take(); // We don't support deltas yet
-                    let catalog: Catalog = serde_json::from_slice(&frame?)?;
-                    return Ok(Some(catalog));
-                }
-            }
-        }
-    }
+        // chat and user flatten to the top level alongside video/audio.
+        let json = serde_json::to_string(&catalog).expect("serialize");
+        assert!(json.contains("\"chat\""), "chat section missing: {json}");
+        assert!(json.contains("\"user\""), "user section missing: {json}");
 
-    /// Wait until the catalog track is closed.
-    pub async fn closed(&self) -> anyhow::Result<()> {
-        Ok(self.track.closed().await?)
-    }
-}
-
-impl From<moq_lite::TrackConsumer> for CatalogConsumer {
-    fn from(inner: moq_lite::TrackConsumer) -> Self {
-        Self::new(inner)
+        let parsed: Catalog = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.ext.chat, catalog.ext.chat);
+        assert_eq!(parsed.ext.user, catalog.ext.user);
     }
 }

--- a/moq-media/src/chat.rs
+++ b/moq-media/src/chat.rs
@@ -91,7 +91,7 @@ impl ChatSubscriber {
     /// Returns `None` when the track ends (peer left or broadcast closed).
     pub async fn recv(&mut self) -> Option<ChatMessage> {
         loop {
-            let group = match self.track.next_group_ordered().await {
+            let group = match self.track.next_group().await {
                 Ok(Some(g)) => g,
                 Ok(None) => {
                     debug!("chat track ended");

--- a/moq-media/src/lib.rs
+++ b/moq-media/src/lib.rs
@@ -11,6 +11,7 @@ pub mod adaptive;
 pub mod audio_backend;
 pub mod audio_file_source;
 mod audio_file_symphonia;
+pub mod catalog;
 pub mod chat;
 pub mod frame_channel;
 pub mod net;
@@ -26,6 +27,8 @@ pub mod sync;
 pub mod test_util;
 pub mod transport;
 mod util;
+
+pub(crate) type OrderedConsumer = moq_mux::container::Consumer<moq_mux::catalog::hang::Container>;
 
 pub use audio_backend::{AudioBackend, AudioBackendOpts, AudioDevice};
 // Re-export from rusty-capture

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -34,9 +34,13 @@ use tracing::{debug, info, warn};
 use crate::codec::AudioCodec;
 #[cfg(any_video_codec)]
 use crate::codec::VideoCodec;
+// The `codec` module is only referenced by the codec-gated encoder selection
+// (e.g. `codec::H264Encoder`), so gate the import to match and avoid an unused
+// import when the crate is built without any codec features.
+#[cfg(any(any_audio_codec, any_video_codec))]
+use crate::codec;
 use crate::{
     catalog::{Catalog, Chat, User},
-    codec,
     format::{
         AudioEncoderConfig, AudioFormat, AudioPreset, VideoEncoderConfig, VideoFormat, VideoFrame,
         VideoPreset,

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -22,8 +22,8 @@ pub use controller::{
     CaptureConfig, PublishCaptureController, PublishOpts, PublishUpdate, PublishUpdateError,
     StreamKind,
 };
-use hang::catalog::{Audio, AudioConfig, Catalog, Chat, User, Video, VideoConfig};
-use moq_lite::{BroadcastProducer, TrackProducer};
+use hang::catalog::{Audio, AudioConfig, Video, VideoConfig};
+use moq_lite::{Broadcast, BroadcastProducer, TrackProducer};
 use n0_error::{Result, StdResultExt};
 use n0_future::task::AbortOnDropHandle;
 use tokio::sync::watch;
@@ -35,6 +35,7 @@ use crate::codec::AudioCodec;
 #[cfg(any_video_codec)]
 use crate::codec::VideoCodec;
 use crate::{
+    catalog::{Catalog, Chat, User},
     codec,
     format::{
         AudioEncoderConfig, AudioFormat, AudioPreset, VideoEncoderConfig, VideoFormat, VideoFrame,
@@ -229,7 +230,7 @@ impl LocalBroadcast {
     /// The consumer returned by [`consume`](Self::consume) is immediately
     /// usable: callers do not need to yield before subscribing to tracks.
     pub fn new() -> Self {
-        let mut producer = BroadcastProducer::default();
+        let mut producer = Broadcast::default().produce();
         let catalog = CatalogProducer::new(&mut producer).expect("not closed");
 
         let stats = crate::stats::PublishStats::default();
@@ -334,7 +335,7 @@ impl LocalBroadcast {
                     break;
                 }
             };
-            let name = track.info.name.clone();
+            let name = track.name.clone();
             if state
                 .lock()
                 .unwrap()
@@ -559,7 +560,9 @@ impl Drop for LocalBroadcast {
     }
 }
 
-struct CatalogProducer {
+#[derive(derive_more::Debug)]
+#[debug("CatalogProducer({})", self.track.name)]
+pub struct CatalogProducer {
     track: TrackProducer,
     catalog: Catalog,
     /// Last published catalog bytes, used to skip duplicate publishes.
@@ -567,7 +570,7 @@ struct CatalogProducer {
 }
 
 impl CatalogProducer {
-    fn new(broadcast: &mut BroadcastProducer) -> Result<Self> {
+    pub fn new(broadcast: &mut BroadcastProducer) -> Result<Self> {
         let track = broadcast
             .create_track(hang::Catalog::default_track())
             .anyerr()?;
@@ -581,25 +584,25 @@ impl CatalogProducer {
         Ok(this)
     }
 
-    fn set_video(&mut self, video: Video) -> Result<()> {
-        self.catalog.video = video;
+    pub fn set_video(&mut self, video: Video) -> Result<()> {
+        self.catalog.hang.video = video;
         self.publish()?;
         Ok(())
     }
 
-    fn set_audio(&mut self, audio: Audio) -> Result<()> {
-        self.catalog.audio = audio;
+    pub fn set_audio(&mut self, audio: Audio) -> Result<()> {
+        self.catalog.hang.audio = audio;
         self.publish()?;
         Ok(())
     }
 
-    fn set_chat(&mut self, chat: Option<Chat>) -> Result<()> {
+    pub fn set_chat(&mut self, chat: Option<Chat>) -> Result<()> {
         self.catalog.chat = chat;
         self.publish()?;
         Ok(())
     }
 
-    fn set_user(&mut self, user: Option<User>) -> Result<()> {
+    pub fn set_user(&mut self, user: Option<User>) -> Result<()> {
         self.catalog.user = user;
         self.publish()?;
         Ok(())
@@ -665,7 +668,7 @@ impl State {
     }
 
     fn start_track(&mut self, track: moq_lite::TrackProducer) -> Result<()> {
-        let name = track.info.name.clone();
+        let name = track.name.clone();
 
         // Try video first.
         match self.video.as_mut() {
@@ -1438,7 +1441,7 @@ mod tests {
 
         let _pipeline = VideoEncoderPipeline::new(source, encoder, sink, Default::default());
 
-        let result = tokio::time::timeout(timeout, consumer.next_group_ordered()).await;
+        let result = tokio::time::timeout(timeout, consumer.next_group()).await;
 
         drop(_pipeline);
 
@@ -1446,7 +1449,7 @@ mod tests {
             .expect("timed out waiting for first video group")
             .expect("track error")
             .expect("track closed without producing any groups");
-        assert_eq!(group.info.sequence, 0, "first group should be sequence 0");
+        assert_eq!(group.sequence, 0, "first group should be sequence 0");
     }
 
     #[cfg(feature = "h264")]

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -585,13 +585,13 @@ impl CatalogProducer {
     }
 
     pub fn set_video(&mut self, video: Video) -> Result<()> {
-        self.catalog.hang.video = video;
+        self.catalog.video = video;
         self.publish()?;
         Ok(())
     }
 
     pub fn set_audio(&mut self, audio: Audio) -> Result<()> {
-        self.catalog.hang.audio = audio;
+        self.catalog.audio = audio;
         self.publish()?;
         Ok(())
     }
@@ -609,7 +609,10 @@ impl CatalogProducer {
     }
 
     fn publish(&mut self) -> Result<()> {
-        let serialized = self.catalog.to_string().anyerr()?;
+        // Serialize the full catalog, not `self.catalog.to_string()`: the latter
+        // resolves through the `Deref` to `hang::Catalog` and serializes only the
+        // video and audio sections, silently dropping the chat and user fields.
+        let serialized = serde_json::to_string(&self.catalog).anyerr()?;
         if self.last_published.as_ref() == Some(&serialized) {
             return Ok(());
         }

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -30,15 +30,15 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-#[cfg(any_audio_codec)]
-use crate::codec::AudioCodec;
-#[cfg(any_video_codec)]
-use crate::codec::VideoCodec;
 // The `codec` module is only referenced by the codec-gated encoder selection
 // (e.g. `codec::H264Encoder`), so gate the import to match and avoid an unused
 // import when the crate is built without any codec features.
 #[cfg(any(any_audio_codec, any_video_codec))]
 use crate::codec;
+#[cfg(any_audio_codec)]
+use crate::codec::AudioCodec;
+#[cfg(any_video_codec)]
+use crate::codec::VideoCodec;
 use crate::{
     catalog::{Catalog, Chat, User},
     format::{
@@ -564,66 +564,44 @@ impl Drop for LocalBroadcast {
     }
 }
 
+/// Publishes the broadcast catalog and exposes setters for its sections.
+///
+/// Wraps [`moq_mux::catalog::Producer`], which owns the `catalog.json` (hang)
+/// and MSF catalog tracks and publishes a fresh snapshot whenever a section
+/// changes.
 #[derive(derive_more::Debug)]
-#[debug("CatalogProducer({})", self.track.name)]
-pub struct CatalogProducer {
-    track: TrackProducer,
-    catalog: Catalog,
-    /// Last published catalog bytes, used to skip duplicate publishes.
-    last_published: Option<String>,
-}
+#[debug("CatalogProducer")]
+pub struct CatalogProducer(#[debug(skip)] moq_mux::catalog::Producer<crate::catalog::IrohLiveExt>);
 
 impl CatalogProducer {
     pub fn new(broadcast: &mut BroadcastProducer) -> Result<Self> {
-        let track = broadcast
-            .create_track(hang::Catalog::default_track())
-            .anyerr()?;
-        let catalog = Catalog::default();
-        let mut this = Self {
-            track,
-            catalog,
-            last_published: None,
-        };
-        this.publish()?;
-        Ok(this)
+        let mut producer =
+            moq_mux::catalog::Producer::with_catalog(broadcast, Catalog::default()).anyerr()?;
+        // `lock()` only publishes when the catalog is mutated, so touch it once
+        // to publish the initial (empty) catalog. Without this, a subscriber
+        // that connects before the first track is configured would block on the
+        // catalog track instead of receiving an empty catalog.
+        producer.lock().video = Video::default();
+        Ok(Self(producer))
     }
 
     pub fn set_video(&mut self, video: Video) -> Result<()> {
-        self.catalog.video = video;
-        self.publish()?;
+        self.0.lock().video = video;
         Ok(())
     }
 
     pub fn set_audio(&mut self, audio: Audio) -> Result<()> {
-        self.catalog.audio = audio;
-        self.publish()?;
+        self.0.lock().audio = audio;
         Ok(())
     }
 
     pub fn set_chat(&mut self, chat: Option<Chat>) -> Result<()> {
-        self.catalog.chat = chat;
-        self.publish()?;
+        self.0.lock().ext.chat = chat;
         Ok(())
     }
 
     pub fn set_user(&mut self, user: Option<User>) -> Result<()> {
-        self.catalog.user = user;
-        self.publish()?;
-        Ok(())
-    }
-
-    fn publish(&mut self) -> Result<()> {
-        // Serialize the full catalog, not `self.catalog.to_string()`: the latter
-        // resolves through the `Deref` to `hang::Catalog` and serializes only the
-        // video and audio sections, silently dropping the chat and user fields.
-        let serialized = serde_json::to_string(&self.catalog).anyerr()?;
-        if self.last_published.as_ref() == Some(&serialized) {
-            return Ok(());
-        }
-        let mut group = self.track.append_group().anyerr()?;
-        group.write_frame(serialized.clone()).anyerr()?;
-        group.finish().anyerr()?;
-        self.last_published = Some(serialized);
+        self.0.lock().ext.user = user;
         Ok(())
     }
 }

--- a/moq-media/src/publish/controller.rs
+++ b/moq-media/src/publish/controller.rs
@@ -113,7 +113,10 @@ impl Error for PublishUpdateError {}
 /// transport layer they use (rooms, direct connections, etc.).
 #[derive(Debug)]
 pub struct PublishCaptureController {
-    #[cfg_attr(not(any_audio_codec), allow(dead_code))]
+    #[cfg_attr(
+        not(any_audio_codec),
+        allow(dead_code, reason = "only read when an audio codec is enabled")
+    )]
     audio_ctx: AudioBackend,
     camera: Arc<Mutex<LocalBroadcast>>,
     screen: Option<LocalBroadcast>,

--- a/moq-media/src/subscribe.rs
+++ b/moq-media/src/subscribe.rs
@@ -12,10 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use hang::{
-    catalog::{AudioConfig, Catalog, CatalogConsumer, VideoConfig},
-    container::OrderedConsumer,
-};
+use hang::catalog::{AudioConfig, VideoConfig};
 use moq_lite::{BroadcastConsumer, Track};
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_future::task::AbortOnDropHandle;
@@ -30,6 +27,8 @@ use crate::adaptive::AdaptiveConfig;
 #[cfg(any_video_codec)]
 use crate::net::NetworkSignals;
 use crate::{
+    OrderedConsumer,
+    catalog::{Catalog, CatalogConsumer, User},
     format::{DecodeConfig, PlaybackConfig, Quality, VideoFrame},
     pipeline::{AudioDecoderPipeline, PipelineContext, VideoDecoderHandle, VideoDecoderPipeline},
     playout::{PlaybackPolicy, SyncMode},
@@ -335,14 +334,14 @@ impl RemoteBroadcast {
 
         let (catalog_watchable, catalog_task) = {
             let track = broadcast
-                .subscribe_track(&Catalog::default_track())
+                .subscribe_track(&hang::catalog::Catalog::default_track())
                 .std_context("missing catalog track")?;
             debug!("catalog track subscribed");
             let mut catalog_consumer = CatalogConsumer::new(track);
             let initial_catalog = catalog_consumer
                 .next()
                 .await
-                .std_context("Broadcast closed before receiving catalog")?
+                .context("Broadcast closed before receiving catalog")?
                 .context("Catalog track closed before receiving catalog")?;
             debug!(
                 video = initial_catalog.video.renditions.len(),
@@ -466,7 +465,7 @@ impl RemoteBroadcast {
     }
 
     /// Returns the user metadata from the catalog, if set by the publisher.
-    pub fn user(&self) -> Option<hang::catalog::User> {
+    pub fn user(&self) -> Option<User> {
         self.catalog().user.clone()
     }
 
@@ -555,7 +554,9 @@ impl RemoteBroadcast {
             })
             .anyerr()?;
         tracing::debug!(track = track_name, "track subscription created");
-        let consumer = OrderedConsumer::new(track_consumer, max_latency);
+        let consumer =
+            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
+                .with_latency(max_latency);
         VideoTrack::from_consumer::<D>(
             track_name.to_string(),
             consumer,
@@ -585,15 +586,15 @@ impl RemoteBroadcast {
         let catalog = self.catalog();
         let audio = &catalog.audio;
         let config = audio.renditions.get(name).context("rendition not found")?;
-        let consumer = OrderedConsumer::new(
-            self.broadcast
-                .subscribe_track(&Track {
-                    name: name.to_string(),
-                    priority: AUDIO_PRIORITY,
-                })
-                .anyerr()?,
-            max_latency,
-        );
+        let track = self
+            .broadcast
+            .subscribe_track(&Track {
+                name: name.to_string(),
+                priority: AUDIO_PRIORITY,
+            })
+            .anyerr()?;
+        let consumer = OrderedConsumer::new(track, moq_mux::catalog::hang::Container::Legacy)
+            .with_latency(max_latency);
         AudioTrack::spawn::<D>(
             name.to_string(),
             consumer,
@@ -745,7 +746,9 @@ impl RemoteBroadcast {
                 priority: VIDEO_PRIORITY,
             })
             .anyerr()?;
-        let consumer = OrderedConsumer::new(track_consumer, self.playback_policy.max_latency);
+        let consumer =
+            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
+                .with_latency(self.playback_policy.max_latency);
         Ok((MoqPacketSource::new(consumer), config))
     }
 
@@ -771,7 +774,9 @@ impl RemoteBroadcast {
                 priority: AUDIO_PRIORITY,
             })
             .anyerr()?;
-        let consumer = OrderedConsumer::new(track_consumer, self.playback_policy.max_latency);
+        let consumer =
+            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
+                .with_latency(self.playback_policy.max_latency);
         Ok((MoqPacketSource::new(consumer), config))
     }
 
@@ -1510,7 +1515,8 @@ fn switch_rendition_v2(
             priority: VIDEO_PRIORITY,
         })
         .anyerr()?;
-    let consumer = hang::container::OrderedConsumer::new(track_consumer, max_latency);
+    let consumer = OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
+        .with_latency(max_latency);
     let source = MoqPacketSource::new(consumer);
     let config: rusty_codecs::config::VideoConfig = config.clone().into();
     let sender = frame_sender.clone();

--- a/moq-media/src/subscribe.rs
+++ b/moq-media/src/subscribe.rs
@@ -341,7 +341,7 @@ impl RemoteBroadcast {
             let initial_catalog = catalog_consumer
                 .next()
                 .await
-                .context("Broadcast closed before receiving catalog")?
+                .anyerr()?
                 .context("Catalog track closed before receiving catalog")?;
             debug!(
                 video = initial_catalog.video.renditions.len(),

--- a/moq-media/src/subscribe.rs
+++ b/moq-media/src/subscribe.rs
@@ -346,6 +346,7 @@ impl RemoteBroadcast {
             debug!(
                 video = initial_catalog.video.renditions.len(),
                 audio = initial_catalog.audio.renditions.len(),
+                chat = initial_catalog.chat.is_some(),
                 "initial catalog received"
             );
             let watchable = Watchable::new(CatalogSnapshot::new(initial_catalog, 0));

--- a/moq-media/src/transport.rs
+++ b/moq-media/src/transport.rs
@@ -1,12 +1,14 @@
 use std::{fmt, future::Future, time::Duration};
 
 use anyhow::Result;
-use hang::container::OrderedProducer;
-use moq_lite::TrackProducer;
+use moq_lite::{Timescale, TrackProducer};
 use tokio::sync::mpsc;
 use tracing::trace;
 
-use crate::format::{EncodedFrame, MediaPacket};
+use crate::{
+    OrderedConsumer,
+    format::{EncodedFrame, MediaPacket},
+};
 
 /// Reads encoded media packets asynchronously.
 ///
@@ -29,11 +31,11 @@ pub trait PacketSink: Send + 'static {
 }
 
 /// Wraps a hang [`OrderedConsumer`](hang::container::OrderedConsumer) as a [`PacketSource`].
-pub struct MoqPacketSource(pub hang::container::OrderedConsumer, u64);
+pub struct MoqPacketSource(pub OrderedConsumer, u64);
 
 impl MoqPacketSource {
     /// Creates a new packet source from an ordered consumer.
-    pub fn new(consumer: hang::container::OrderedConsumer) -> Self {
+    pub fn new(consumer: OrderedConsumer) -> Self {
         Self(consumer, 0)
     }
 }
@@ -50,7 +52,7 @@ impl PacketSource for MoqPacketSource {
         let seq = self.1;
         match self.0.read().await {
             Ok(Some(frame)) => {
-                let pkt: MediaPacket = frame.into();
+                let pkt: MediaPacket = moq_frame_to_media_packet(frame);
                 throttled_tracing::trace_every!(
                     Duration::from_secs(2),
                     seq,
@@ -72,16 +74,27 @@ impl PacketSource for MoqPacketSource {
     }
 }
 
+fn moq_frame_to_media_packet(frame: moq_mux::container::Frame) -> MediaPacket {
+    MediaPacket {
+        timestamp: frame.timestamp.into(),
+        payload: frame.payload.into(),
+        is_keyframe: frame.keyframe,
+    }
+}
+
 /// Wraps a hang [`OrderedProducer`] as a [`PacketSink`].
 ///
 /// Handles keyframe grouping: calls `keyframe()` on the underlying producer
 /// when an `EncodedFrame` with `is_keyframe = true` is written.
-pub struct MoqPacketSink(OrderedProducer);
+pub struct MoqPacketSink(moq_mux::container::Producer<moq_mux::catalog::hang::Container>);
 
 impl MoqPacketSink {
     /// Creates a new sink from a [`TrackProducer`].
     pub fn new(producer: TrackProducer) -> Self {
-        Self(OrderedProducer::new(producer))
+        Self(moq_mux::container::Producer::new(
+            producer,
+            moq_mux::catalog::hang::Container::Legacy,
+        ))
     }
 }
 
@@ -93,10 +106,12 @@ impl fmt::Debug for MoqPacketSink {
 
 impl PacketSink for MoqPacketSink {
     fn write(&mut self, packet: EncodedFrame) -> Result<()> {
-        if packet.is_keyframe {
-            self.0.keyframe()?;
-        }
-        self.0.write(packet.to_hang_frame())?;
+        let frame = moq_mux::container::Frame {
+            timestamp: Timescale::from_millis_unchecked(packet.timestamp.as_millis() as u64),
+            payload: packet.payload,
+            keyframe: packet.is_keyframe,
+        };
+        self.0.write(frame)?;
         Ok(())
     }
 

--- a/rusty-codecs/src/config.rs
+++ b/rusty-codecs/src/config.rs
@@ -178,19 +178,18 @@ mod hang_interop {
 
     impl From<VideoConfig> for hang::catalog::VideoConfig {
         fn from(c: VideoConfig) -> Self {
-            Self {
-                codec: c.codec.into(),
-                description: c.description,
-                coded_width: c.coded_width,
-                coded_height: c.coded_height,
-                display_ratio_width: c.display_ratio_width,
-                display_ratio_height: c.display_ratio_height,
-                bitrate: c.bitrate,
-                framerate: c.framerate,
-                optimize_for_latency: c.optimize_for_latency,
-                container: Default::default(),
-                jitter: None,
-            }
+            let mut config = Self::new(c.codec);
+            config.description = c.description;
+            config.coded_width = c.coded_width;
+            config.coded_height = c.coded_height;
+            config.display_ratio_width = c.display_ratio_width;
+            config.display_ratio_height = c.display_ratio_height;
+            config.bitrate = c.bitrate;
+            config.framerate = c.framerate;
+            config.optimize_for_latency = c.optimize_for_latency;
+            config.container = Default::default();
+            config.jitter = None;
+            config
         }
     }
 
@@ -208,15 +207,10 @@ mod hang_interop {
 
     impl From<AudioConfig> for hang::catalog::AudioConfig {
         fn from(c: AudioConfig) -> Self {
-            Self {
-                codec: c.codec.into(),
-                sample_rate: c.sample_rate,
-                channel_count: c.channel_count,
-                bitrate: c.bitrate,
-                description: c.description,
-                container: Default::default(),
-                jitter: None,
-            }
+            let mut config = Self::new(c.codec, c.sample_rate, c.channel_count);
+            config.bitrate = c.bitrate;
+            config.description = c.description;
+            config
         }
     }
 
@@ -324,16 +318,16 @@ mod hang_interop {
 
     // EncodedFrame ↔ hang::container::Frame conversions
 
-    impl From<hang::container::OrderedFrame> for crate::format::MediaPacket {
-        fn from(f: hang::container::OrderedFrame) -> Self {
-            let is_keyframe = f.is_keyframe();
-            Self {
-                timestamp: f.timestamp.into(),
-                payload: f.payload,
-                is_keyframe,
-            }
-        }
-    }
+    // impl From<hang::container::Frame> for crate::format::MediaPacket {
+    //     fn from(f: hang::container::Frame) -> Self {
+    //         let is_keyframe = f.is_keyframe();
+    //         Self {
+    //             timestamp: f.timestamp.into(),
+    //             payload: f.payload,
+    //             is_keyframe,
+    //         }
+    //     }
+    // }
 
     impl crate::format::EncodedFrame {
         /// Converts to a hang [`Frame`](hang::container::Frame) for MoQ transport.
@@ -343,7 +337,7 @@ mod hang_interop {
                     self.timestamp.as_micros() as u64
                 )
                 .expect("timestamp overflow"),
-                payload: self.payload.clone().into(),
+                payload: self.payload.clone(),
             }
         }
     }

--- a/rusty-codecs/src/config.rs
+++ b/rusty-codecs/src/config.rs
@@ -315,30 +315,4 @@ mod hang_interop {
             }
         }
     }
-
-    // EncodedFrame ↔ hang::container::Frame conversions
-
-    // impl From<hang::container::Frame> for crate::format::MediaPacket {
-    //     fn from(f: hang::container::Frame) -> Self {
-    //         let is_keyframe = f.is_keyframe();
-    //         Self {
-    //             timestamp: f.timestamp.into(),
-    //             payload: f.payload,
-    //             is_keyframe,
-    //         }
-    //     }
-    // }
-
-    impl crate::format::EncodedFrame {
-        /// Converts to a hang [`Frame`](hang::container::Frame) for MoQ transport.
-        pub fn to_hang_frame(&self) -> hang::container::Frame {
-            hang::container::Frame {
-                timestamp: hang::container::Timestamp::from_micros(
-                    self.timestamp.as_micros() as u64
-                )
-                .expect("timestamp overflow"),
-                payload: self.payload.clone(),
-            }
-        }
-    }
 }

--- a/rusty-codecs/src/format.rs
+++ b/rusty-codecs/src/format.rs
@@ -1005,7 +1005,7 @@ pub struct VideoEncoderConfig {
             feature = "videotoolbox",
             feature = "android"
         )),
-        allow(dead_code)
+        allow(dead_code, reason = "only read by H.264 encoders")
     )]
     pub(crate) nal_format: NalFormat,
 }


### PR DESCRIPTION
This updates iroh to 1.0, all iroh-related crates to the latest version, and all moq/hang crates to the latest released versions. We no longer need git dependencies on moq crates.