### PR TITLE
deps: update cpal to 0.18.1 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -2138,17 +2138,19 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.18.0"
-source = "git+https://github.com/RustAudio/cpal.git?rev=e172208edd47f0077077d47b9f6991bdc248fd36#e172208edd47f0077077d47b9f6991bdc248fd36"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
 dependencies = [
  "alsa",
+ "block2 0.6.2",
  "coreaudio-rs",
  "dasp_sample",
  "jack",
- "jni 0.21.1",
+ "jni 0.22.4",
  "js-sys",
  "libc",
- "mach2 0.5.0",
+ "mach2 0.6.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -2160,10 +2162,9 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6496,12 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
@@ -8002,6 +8000,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]

--- a/moq-media-egui/src/overlay.rs
+++ b/moq-media-egui/src/overlay.rs
@@ -229,7 +229,7 @@ impl DebugOverlay {
                 painter.rect_filled(section_rect, 2.0, egui::Color32::from_white_alpha(30));
                 painter.line_segment(
                     [section_rect.left_bottom(), section_rect.right_bottom()],
-                    egui::Stroke::new(1.0, egui::Color32::from_white_alpha(80)),
+                    egui::Stroke::new(1.0_f32, egui::Color32::from_white_alpha(80)),
                 );
             }
             if response.clicked() {
@@ -252,7 +252,7 @@ impl DebugOverlay {
                         egui::pos2(sep_x, bar_rect.min.y + 3.0),
                         egui::pos2(sep_x, bar_rect.max.y - 3.0),
                     ],
-                    egui::Stroke::new(1.0, egui::Color32::from_white_alpha(40)),
+                    egui::Stroke::new(1.0_f32, egui::Color32::from_white_alpha(40)),
                 );
                 x += 12.0;
             }
@@ -334,7 +334,7 @@ impl DebugOverlay {
                 painter.rect_filled(section_rect, 2.0, egui::Color32::from_white_alpha(30));
                 painter.line_segment(
                     [section_rect.left_bottom(), section_rect.right_bottom()],
-                    egui::Stroke::new(1.0, egui::Color32::from_white_alpha(80)),
+                    egui::Stroke::new(1.0_f32, egui::Color32::from_white_alpha(80)),
                 );
             }
             if response.clicked() {
@@ -356,7 +356,7 @@ impl DebugOverlay {
                         egui::pos2(sep_x, bar_rect.min.y + 3.0),
                         egui::pos2(sep_x, bar_rect.max.y - 3.0),
                     ],
-                    egui::Stroke::new(1.0, egui::Color32::from_white_alpha(40)),
+                    egui::Stroke::new(1.0_f32, egui::Color32::from_white_alpha(40)),
                 );
                 x += 12.0;
             }
@@ -631,7 +631,7 @@ fn paint_sparkline(
         })
         .collect();
 
-    let stroke = egui::Stroke::new(1.0, color.linear_multiply(0.7));
+    let stroke = egui::Stroke::new(1.0_f32, color.linear_multiply(0.7));
     for pair in points.windows(2) {
         painter.line_segment([pair[0], pair[1]], stroke);
     }
@@ -721,7 +721,7 @@ fn paint_timeline_panel(
                 egui::pos2(x, rect.min.y),
                 egui::pos2(x, rect.max.y - AXIS_H),
             ],
-            egui::Stroke::new(1.0, COLOR_GRID),
+            egui::Stroke::new(1.0_f32, COLOR_GRID),
         );
     }
 
@@ -770,7 +770,7 @@ fn paint_timeline_panel(
                 let y2 = lat_rect.max.y - (l2 / max_lat) * h;
                 painter.line_segment(
                     [egui::pos2(x1, y1), egui::pos2(x2, y2)],
-                    egui::Stroke::new(1.5, latency_color((l1 + l2) / 2.0)),
+                    egui::Stroke::new(1.5_f32, latency_color((l1 + l2) / 2.0)),
                 );
             }
             if let Some((_, lat)) = latencies.last() {
@@ -838,7 +838,7 @@ fn paint_timeline_panel(
             if entry.is_keyframe {
                 painter.line_segment(
                     [r.left_top(), r.left_bottom()],
-                    egui::Stroke::new(1.0, egui::Color32::WHITE),
+                    egui::Stroke::new(1.0_f32, egui::Color32::WHITE),
                 );
             }
         }
@@ -892,7 +892,7 @@ fn paint_timeline_panel(
                 egui::pos2(sync_rect.min.x, zero_y),
                 egui::pos2(sync_rect.max.x, zero_y),
             ],
-            egui::Stroke::new(1.0, egui::Color32::from_rgb(60, 60, 60)),
+            egui::Stroke::new(1.0_f32, egui::Color32::from_rgb(60, 60, 60)),
         );
 
         let g = painter.layout_no_wrap("A/V".to_string(), font.clone(), COLOR_GRAY);
@@ -939,7 +939,7 @@ fn paint_timeline_panel(
                 };
                 painter.line_segment(
                     [egui::pos2(x1, y1), egui::pos2(x2, y2)],
-                    egui::Stroke::new(1.0, color),
+                    egui::Stroke::new(1.0_f32, color),
                 );
             }
             if let Some((_, offset)) = sync_points.last() {
@@ -992,7 +992,7 @@ fn paint_timeline_panel(
                 } else {
                     COLOR_RED
                 };
-                painter.line_segment([pair[0], pair[1]], egui::Stroke::new(1.5, color));
+                painter.line_segment([pair[0], pair[1]], egui::Stroke::new(1.5_f32, color));
             }
         }
         let buf_ms = timing.audio_buf_ms.current();
@@ -1031,7 +1031,7 @@ fn paint_timeline_panel(
                 })
                 .collect();
             for pair in points.windows(2) {
-                painter.line_segment([pair[0], pair[1]], egui::Stroke::new(1.5, COLOR_CYAN));
+                painter.line_segment([pair[0], pair[1]], egui::Stroke::new(1.5_f32, COLOR_CYAN));
             }
         }
         let g = painter.layout_no_wrap(

--- a/moq-media/Cargo.toml
+++ b/moq-media/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.100"
 derive_more = { version = "2.0.1", features = ["display", "debug", "eq", "deref"] }
-cpal = { git = "https://github.com/RustAudio/cpal.git", rev = "e172208edd47f0077077d47b9f6991bdc248fd36" }
+cpal = "0.18.1"
 fixed-resample = { version = "0.9", features = ["resampler"] }
 ringbuf = "0.4"
 hang = { workspace = true }

--- a/moq-media/src/audio_backend.rs
+++ b/moq-media/src/audio_backend.rs
@@ -720,11 +720,10 @@ fn list_devices(direction: Direction) -> Vec<AudioDevice> {
         let Ok(devices) = devices else { continue };
         for device in devices {
             let Ok(id) = device.id() else { continue };
-            #[allow(
-                deprecated,
-                reason = "DeviceTrait::name is deprecated in cpal 0.18 but description() is not yet stable on all backends"
-            )]
-            let name = device.name().unwrap_or_else(|_| id.to_string());
+            let name = device
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| id.to_string());
             let is_default = default_id.as_ref() == Some(&id);
             out.push(AudioDevice {
                 id: DeviceId(id),
@@ -1233,7 +1232,7 @@ struct TrackedInput {
 #[derive(Debug)]
 struct StreamErrorInfo {
     direction: &'static str,
-    error: cpal::StreamError,
+    error: cpal::Error,
 }
 
 impl fmt::Debug for AudioDriver {
@@ -1367,8 +1366,8 @@ impl AudioDriver {
 
     fn drain_errors(&mut self) {
         while let Ok(err_info) = self.error_rx.try_recv() {
-            match &err_info.error {
-                cpal::StreamError::BufferUnderrun => {
+            match err_info.error.kind() {
+                cpal::ErrorKind::Xrun => {
                     self.underrun_count += 1;
                     if self.underrun_window_start.elapsed() > Duration::from_secs(5) {
                         self.underrun_count = 1;
@@ -1384,11 +1383,11 @@ impl AudioDriver {
                         self.attempt_restart();
                     }
                 }
-                cpal::StreamError::DeviceNotAvailable => {
+                cpal::ErrorKind::DeviceNotAvailable => {
                     warn!(direction = err_info.direction, "audio device unavailable");
                     self.attempt_restart();
                 }
-                cpal::StreamError::StreamInvalidated => {
+                cpal::ErrorKind::StreamInvalidated => {
                     warn!(direction = err_info.direction, "audio stream invalidated");
                     self.attempt_restart();
                 }

--- a/rusty-codecs/src/codec/v4l2/decoder.rs
+++ b/rusty-codecs/src/codec/v4l2/decoder.rs
@@ -338,7 +338,7 @@ fn decoder_thread(
 }
 
 /// YU12 (I420) fourcc: 'Y','U','1','2' = 0x32315559
-const PIXFMT_YU12: u32 = u32::from_le_bytes([b'Y', b'U', b'1', b'2']);
+const PIXFMT_YU12: u32 = u32::from_le_bytes(*b"YU12");
 
 /// Extracts a decoded frame from a dequeued CAPTURE buffer as NV12.
 ///


### PR DESCRIPTION
Replaces the git-pinned cpal (`0.18.0` dev rev `e172208`) with the crates.io release `0.18.1`, removing the git dependency from the graph.

The release API differs from the pinned dev rev, so `moq-media/src/audio_backend.rs` needed a small migration:

- **Stream errors:** `cpal::StreamError` is gone; the stream error callback now delivers `cpal::Error`. The error handling matches over `cpal::ErrorKind` via `error.kind()`, mapping the old variants (`BufferUnderrun` → `Xrun`, `DeviceNotAvailable`, `StreamInvalidated`).
- **Device name:** `DeviceTrait::name()` is removed in the release (it was only deprecated in the dev rev); switched to `device.description()?.name()`.

### Verification
- `cargo check -p moq-media` and `cargo check -p moq-media --tests` pass on default features.
- `Cargo.lock` now resolves `cpal 0.18.1` from crates.io; the lock diff is entirely cpal-scoped (its transitive deps alsa, jni, mach2, block2, windows-core move with it).
- `--all-features` fails on an unrelated, pre-existing `cros-libva 0.0.12` bindgen issue on the `vaapi` path, not touched by this change.

