### PR TITLE
fix(android): clear buffered camera frame on start/stop

### DIFF
--- a/moq-media-android/src/camera.rs
+++ b/moq-media-android/src/camera.rs
@@ -68,12 +68,23 @@ impl VideoSource for CameraFrameSource {
     }
 
     fn start(&mut self) -> Result<()> {
+        // Drop any frame left over from a previous session. The source is a
+        // process-lifetime singleton on Android, so a stale frame from a prior
+        // call would otherwise be the first frame the new pipeline consumes —
+        // anchoring downstream PTS pacing (SharedVideoSource) on an old
+        // timestamp and throttling the whole encode path to ~1 fps.
+        self.pending_frame = None;
         self.started = true;
         Ok(())
     }
 
     fn stop(&mut self) -> Result<()> {
         self.started = false;
+        // Clear the buffered frame so it cannot leak into the next session.
+        // The camera callback may still push a few frames after stop() (the
+        // app-side capture stops asynchronously), which is why start() also
+        // clears defensively.
+        self.pending_frame = None;
         Ok(())
     }
 }
@@ -103,12 +114,10 @@ impl VideoSource for SharedCameraSource {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.inner.lock().expect("poisoned").started = true;
-        Ok(())
+        self.inner.lock().expect("poisoned").start()
     }
 
     fn stop(&mut self) -> Result<()> {
-        self.inner.lock().expect("poisoned").started = false;
-        Ok(())
+        self.inner.lock().expect("poisoned").stop()
     }
 }


### PR DESCRIPTION
## Problem

`CameraFrameSource` is a process-lifetime singleton on Android, so a frame left over from a previous capture session survives across sessions. On the next `start()`, that stale frame is the first one the pipeline pops, which anchors `SharedVideoSource`'s PTS pacing on an old timestamp. The pacing loop then sleeps for the stale frame's age on *every* subsequent frame, throttling the encode path to ~1 fps for the rest of the session.

### Reproduction
Android ↔ macOS video call. The first call is smooth (30 fps). Hang up and immediately start a second call: the second (and every later) call is stuck at ~1 fps on the Android sender, while CameraX itself keeps delivering 30 fps. The throttle magnitude equals the gap between hang-up and re-dial.

## Fix

- Clear `pending_frame` in both `start()` and `stop()` so no frame leaks between sessions. `stop()` clears eagerly; `start()` clears defensively because the camera callback may still push frames after `stop()` (app-side capture stops asynchronously).
- Route `SharedCameraSource::start`/`stop` through the inner source's methods instead of poking the `started` flag directly, so the cleanup is not bypassed.