### PR TITLE
deps/moq-net-0.2

### DIFF
--- a/.github/workflows/ci-aarch64-zig.yml
+++ b/.github/workflows/ci-aarch64-zig.yml
@@ -9,6 +9,12 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  # One run per workflow per ref. A new push supersedes whatever is still running,
+  # so force-pushes and rapid follow-ups don't leave stale jobs burning runners.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    # Weekly check for excluded workspace members (moq-media-dioxus).
+    # Weekly run of the whole suite, including the dioxus feature-unification check.
     - cron: "0 6 * * 1"
 
 env:
@@ -67,8 +67,10 @@ jobs:
       - run: cargo clippy --locked --workspace --exclude pi-zero-demo --exclude pi-zero-minimal --all-targets --all-features -- -D warnings
       - run: cargo nextest run --locked --workspace --exclude pi-zero-demo --exclude pi-zero-minimal
 
-  # moq-media-dioxus is excluded from default-members (heavy dep tree).
-  # Check it weekly to catch breakage early.
+  # The Linux and macOS jobs above pass --workspace, which overrides
+  # default-members and already compiles moq-media-dioxus. This job checks it as
+  # a lone package, where feature unification differs from a workspace-wide build
+  # and can surface breakage the other jobs hide.
   check-dioxus:
     name: Check moq-media-dioxus
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     # Weekly run of the whole suite, including the dioxus feature-unification check.
     - cron: "0 6 * * 1"
 
+concurrency:
+  # One run per workflow per ref. A new push supersedes whatever is still running,
+  # so force-pushes and rapid follow-ups don't leave stale jobs burning runners.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  # Serialised, not cancelled: this replaces assets on the rolling release, and a
+  # run killed mid-upload can leave binaries and SHA256SUMS out of sync.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -555,18 +555,6 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -734,7 +722,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "url",
@@ -986,12 +974,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
@@ -1003,19 +985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bindgen"
@@ -1338,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
 ]
 
 [[package]]
@@ -1426,6 +1405,12 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 
 [[package]]
 name = "bytestring"
@@ -1571,9 +1556,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"
@@ -1833,23 +1818,6 @@ dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "compression-codecs"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
-dependencies = [
- "compression-core",
- "flate2",
- "memchr",
-]
-
-[[package]]
-name = "compression-core"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -2138,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
+checksum = "6f02e8d0327b42d3e2e4ab2119af397344eb9fc54a34bf0ddeaa1277af8681f1"
 dependencies = [
  "alsa",
  "block2 0.6.2",
@@ -2166,6 +2134,12 @@ dependencies = [
  "windows 0.62.2",
  "windows-core 0.62.2",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2320,12 +2294,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -2346,7 +2324,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2405,6 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -2493,7 +2474,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -2585,7 +2565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2652,37 +2632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,7 +2669,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -2730,7 +2678,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2813,7 +2763,7 @@ dependencies = [
  "subsecond",
  "thiserror 2.0.18",
  "tracing",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3032,7 +2982,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3082,6 +3032,18 @@ dependencies = [
  "libc",
  "once_cell",
  "winapi",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3251,16 +3213,17 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
+ "der 0.8.0",
+ "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3294,7 +3257,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.10.1",
  "serde",
- "sha2 0.11.0",
+ "sha2",
  "signature 3.0.0",
  "subtle",
  "zeroize",
@@ -3419,20 +3382,20 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "crypto-common 0.2.1",
+ "digest 0.11.2",
  "ff",
- "generic-array",
  "group",
- "hkdf",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -3640,7 +3603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3775,11 +3738,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4214,7 +4177,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -4378,7 +4340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.11.1",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -4402,7 +4364,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "glutin",
  "raw-window-handle",
  "winit 0.30.13",
@@ -4549,12 +4511,12 @@ checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4607,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "hang"
-version = "0.19.1"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32320866e0e43ac542badd472790d8267dcca0284a344bf9a55465278ff44f3d"
+checksum = "589242ee78fc98effc9187b0be2060533312fe1217c737567b0aa233fc437711"
 dependencies = [
  "bytes",
  "derive_more",
@@ -4836,21 +4798,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4916,42 +4869,49 @@ dependencies = [
 
 [[package]]
 name = "http-cache"
-version = "0.21.0"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a"
+checksum = "e5578f9c6c2ad8403802d209d1ffe8a2a15d3f89bfaabca9deaa977947dba241"
 dependencies = [
- "async-trait",
- "bincode",
+ "bytes",
+ "futures",
+ "hex",
  "http",
+ "http-body",
  "http-cache-semantics",
  "httpdate",
+ "log",
  "moka",
+ "pin-project-lite",
+ "postcard",
  "serde",
  "url",
 ]
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.16.0"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886"
+checksum = "8b8eff2dd41dcc485744bd8ce476cf0fe2df289ba8b49c1750b7c887ef7a07b5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "http",
+ "http-body",
+ "http-body-util",
  "http-cache",
  "http-cache-semantics",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "reqwest-middleware",
- "serde",
  "url",
 ]
 
 [[package]]
 name = "http-cache-semantics"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http",
  "http-serde",
@@ -4999,11 +4959,13 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -5050,7 +5012,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -5470,14 +5432,14 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
+checksum = "329552fad4e46b5ccb4439d5635216f6289eec2c46f3fde4bc732d762694b9e5"
 dependencies = [
  "backon",
  "blake3",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "ctutils",
  "data-encoding",
  "derive_more",
@@ -5521,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
+checksum = "3ccf4cde68a02ef03c0095ab2c031c6adfe508f3bc8e7c258558a027ebe64a8e"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -5540,12 +5502,12 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
+checksum = "9a41224eb0140a5c519935d4073fc6b236d174080be401f9bf7da126b2ee3aa4"
 dependencies = [
  "arc-swap",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "derive_more",
  "hickory-resolver",
  "iroh-base",
@@ -5706,7 +5668,7 @@ dependencies = [
  "rustls",
  "serial_test",
  "tokio",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5756,13 +5718,13 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
+checksum = "1b5f6f07e2c9b0c4bc82e2864be09f4aea4320165d5316e668616dbc822f428a"
 dependencies = [
  "blake3",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "data-encoding",
  "derive_more",
  "getrandom 0.4.2",
@@ -5795,7 +5757,6 @@ dependencies = [
  "tokio-websockets",
  "tracing",
  "url",
- "vergen-gitcl",
  "webpki-roots",
  "ws_stream_wasm",
 ]
@@ -6078,12 +6039,12 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -6091,6 +6052,7 @@ dependencies = [
  "serde_json",
  "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -6133,11 +6095,13 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kio"
-version = "0.4.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0baba9496c17ae461ad833edbe1f10612044c7d2b58cdae8c5e9acb9388bfb5"
+checksum = "36d64d03bab237df643a5013adcf07764e4bd3265117e4c4f69e856d37928e69"
 dependencies = [
+ "loom",
  "smallvec",
+ "web-async",
 ]
 
 [[package]]
@@ -6441,6 +6405,7 @@ checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if 1.0.4",
  "generator",
+ "pin-utils",
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
@@ -6469,16 +6434,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "m3u8-rs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03cd3335fb5f2447755d45cda9c70f76013626a9db44374973791b0926a86c3"
-dependencies = [
- "chrono",
- "nom 7.1.3",
-]
 
 [[package]]
 name = "mac-addr"
@@ -6769,27 +6724,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "moq-json"
-version = "0.0.3"
+name = "moq-flate"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de30545123e2391b890c01f82650a868f8b4e87bc57579627c32d1a0ece51b1"
+checksum = "9c7fb9c1c34a59487494ab90f74230f504f440fb3682397a6623d72f656abef7"
 dependencies = [
  "bytes",
- "json-patch",
- "kio",
- "moq-net",
- "serde",
- "serde_json",
+ "flate2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "moq-loc"
-version = "0.1.0"
+name = "moq-json"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489094f71ebaef7f33f400947a9fd9ef1cd65b390a36b83e356920bf91866cae"
+checksum = "852e2fa49422b9afa76940b454e8942aeeca05eb77834259604badbb91fcbf8b"
 dependencies = [
  "bytes",
+ "json-patch",
+ "kio",
+ "moq-flate",
+ "moq-net",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "moq-loc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59047a17afded7796f009bfbc51c92ef210be5e523417c7c87dd53f0a6f9ced2"
+dependencies = [
+ "bytes",
+ "moq-net",
  "thiserror 2.0.18",
 ]
 
@@ -6879,9 +6849,9 @@ dependencies = [
 
 [[package]]
 name = "moq-msf"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccfbfb04d4fc9f7f3f31662bf12c590dbfcd79ecc4113496c07bdf497a2636d"
+checksum = "df8f9a6121082c2536d4af7f4ed13f27e4a1a1eefe90b6e7657fc57bf7bc4934"
 dependencies = [
  "serde",
  "serde_json",
@@ -6890,17 +6860,16 @@ dependencies = [
 
 [[package]]
 name = "moq-mux"
-version = "0.5.5"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e36e4c772895d07efda440bd0edf10d2423f9f791f59b857d9700beeb72516"
+checksum = "f57d28a8d0e6240efdfb3e308bff5211881b154aa3f7c6f495325602680444a8"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "h264-parser",
  "hang",
  "kio",
- "m3u8-rs",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -6909,37 +6878,44 @@ dependencies = [
  "mp4-atom",
  "mpeg2ts",
  "num_enum",
- "reqwest 0.12.28",
  "scuffle-av1",
  "scuffle-h265",
  "serde",
+ "serde_json",
+ "serde_with",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
+ "web-async",
  "webm-iterable",
 ]
 
 [[package]]
 name = "moq-native"
-version = "0.17.1"
+version = "0.19.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f6c4ee8740b6ad911f9d05d7a617ec437450532afcb71e38b01959e193c930"
+checksum = "4c98baa5038e449ddb837a09d4e47c642abf56cfa75b685741bc31b1b47bd960"
 dependencies = [
  "clap",
+ "dns-lookup",
  "futures",
  "hex",
  "humantime",
  "humantime-serde",
+ "jni 0.22.4",
+ "libc",
  "moq-net",
+ "noq-proto",
  "notify",
  "parking_lot",
+ "qmux",
  "quinn",
  "rand 0.10.1",
  "rcgen",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rustls",
- "rustls-native-certs",
+ "rustls-platform-verifier 0.7.0",
  "rustls-webpki",
  "serde",
  "serde_with",
@@ -6954,13 +6930,15 @@ dependencies = [
  "web-transport-noq",
  "web-transport-proto",
  "web-transport-trait",
+ "webpki-roots",
+ "x509-parser",
 ]
 
 [[package]]
 name = "moq-net"
-version = "0.1.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e78427132ce874978ef554d9cab419762abd115ba5c97f4bea4ea0aa523d3f"
+checksum = "6fdd7886cdf9250bda506b7a30758e137ac051eaaf06101475092b2bfb6ce5c3"
 dependencies = [
  "bytes",
  "futures",
@@ -6968,9 +6946,7 @@ dependencies = [
  "num_enum",
  "rand 0.10.1",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "web-async",
  "web-transport-trait",
@@ -6978,49 +6954,69 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.12.10"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63f0da535a384460bb6d9442f9a7002c4dc9a31d0ac9ae0c7f9b6585657c698"
+checksum = "50fb8364a7f5cbaf77929153331ffb38e0640ba28e10331d9433c196efb04cb7"
 dependencies = [
  "anyhow",
  "axum",
  "axum-server",
  "bytes",
+ "bytesize",
  "clap",
  "futures",
  "http-body",
  "http-cache-reqwest",
+ "humantime",
+ "humantime-serde",
  "jsonwebtoken",
  "moq-native",
  "moq-net",
+ "moq-stats",
  "moq-token",
- "notify",
- "reqwest 0.12.28",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
  "reqwest-middleware",
  "rustls",
  "sd-notify",
  "serde",
  "serde_json",
  "serde_with",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "toml 1.1.2+spec-1.1.0",
- "tower-http",
+ "tower-http 0.7.0",
  "tower-service",
  "tracing",
  "url",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "moq-stats"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e0d6986e166f67d74d9abe60241abc899e33088d8226b5bfc99dc337d7d15a"
+dependencies = [
+ "moq-json",
+ "moq-net",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-async",
 ]
 
 [[package]]
 name = "moq-token"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94369228b8b5db87cea16e4c1ba9d36fb791f7854f73f5b7519a8eb6d3ecb1bf"
+checksum = "dcfcfb1f193c52923d688c20868ceef44eff3be1e1c938e253d8d33ce19147b9"
 dependencies = [
  "aws-lc-rs",
- "base64",
- "elliptic-curve",
+ "base64 0.23.1",
  "jsonwebtoken",
  "p256",
  "p384",
@@ -7059,9 +7055,9 @@ dependencies = [
 
 [[package]]
 name = "mp4-atom"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b338be0a8d66954dfb183f8469913c9c435d48885e801debde0953de74563"
+checksum = "f3d7433df407a636db7047600422af07145adf6ee25e0622745b0131516dbc3c"
 dependencies = [
  "bytes",
  "derive_more",
@@ -7128,7 +7124,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "derive_more",
  "futures-buffered",
  "futures-lite",
@@ -7229,7 +7225,7 @@ dependencies = [
  "bit-set 0.8.0",
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "codespan-reporting 0.12.0",
  "half",
  "hashbrown 0.16.1",
@@ -7311,9 +7307,9 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2 0.6.2",
  "dispatch2",
@@ -7324,12 +7320,36 @@ dependencies = [
  "mac-addr",
  "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route 0.31.0",
  "netlink-sys",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation 0.3.2",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netdev"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5f88621a4b468e8ce92626f847cc02462cef3e06d793baa8b1c8617e304b20"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "jni 0.21.1",
+ "libc",
+ "mac-addr",
+ "ndk-context",
+ "netlink-packet-core",
+ "netlink-packet-route 0.31.0",
+ "netlink-sys",
+ "objc2-core-foundation",
  "objc2-system-configuration",
  "once_cell",
  "plist",
@@ -7350,18 +7370,6 @@ name = "netlink-packet-route"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -7410,13 +7418,13 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.19.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
+checksum = "39da9cad5f23aa43401f09497d3b280e51b5feba115d9ffbf38ca35d6ff95e96"
 dependencies = [
  "atomic-waker",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "derive_more",
  "ipnet",
  "js-sys",
@@ -7424,7 +7432,8 @@ dependencies = [
  "n0-error 1.0.0",
  "n0-future",
  "n0-watcher 1.0.0",
- "netdev",
+ "netdev 0.45.0",
+ "netdev 0.46.1",
  "netlink-packet-core",
  "netlink-packet-route 0.31.0",
  "netlink-proto",
@@ -7508,7 +7517,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -7620,12 +7629,12 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "noq"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
+checksum = "f1e6c57353d26be91a242f0ec96073066c4481a03f6be874daafb18902394515"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "derive_more",
  "noq-proto",
  "noq-udp",
@@ -7642,9 +7651,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
+checksum = "9a46813e306c29c4f86357b6ffa39a8e1c97bb274b9a296a19a56d62e4111225"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -7672,11 +7681,11 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
+checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "socket2",
  "tracing",
@@ -7720,12 +7729,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7865,15 +7883,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -8250,6 +8259,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8595,26 +8614,29 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -8740,7 +8762,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -9060,13 +9082,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -9142,11 +9164,11 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.19.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
+checksum = "ca97242f016e090a25330613bc2382aab65eb22f9149dbe84d8f8e711d49a530"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_more",
  "hyper-util",
@@ -9263,12 +9285,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -9327,6 +9367,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "qmux"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a86f3c22d13c8b2159b795eced3fa4eee0316527be16b56626f3d063b02a1"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "tracing",
+ "web-transport-proto",
+ "web-transport-trait",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9371,18 +9430,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -9394,7 +9453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -9437,12 +9496,12 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9842,7 +9901,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -9867,7 +9926,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -9882,7 +9941,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -9896,6 +9955,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
@@ -9904,7 +9964,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -9915,16 +9975,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.12.28",
- "serde",
- "thiserror 1.0.69",
+ "reqwest 0.13.2",
+ "thiserror 2.0.18",
  "tower-service",
 ]
 
@@ -9936,12 +9995,12 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -10166,7 +10225,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10225,7 +10284,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10246,7 +10305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10550,14 +10609,14 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
+ "base16ct",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -10592,7 +10651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10749,7 +10808,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -10781,7 +10840,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
@@ -10845,7 +10904,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
  "ref-cast",
 ]
@@ -10866,17 +10925,6 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "sha2"
@@ -10939,6 +10987,10 @@ name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -10973,9 +11025,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+checksum = "2b6f884fa9a8d48101774bfbd3aeb81e968dd22cffd19a372da69f183db22c1a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -11703,6 +11755,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11788,7 +11854,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11817,7 +11883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11911,9 +11977,7 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -12072,6 +12136,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12092,7 +12172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -12222,19 +12302,29 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "async-compression",
  "bitflags 2.11.1",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -12359,6 +12449,24 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12532,7 +12640,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -12717,43 +12825,6 @@ dependencies = [
  "naga 27.0.3",
  "thiserror 2.0.18",
  "vello_encoding",
-]
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
 ]
 
 [[package]]
@@ -12953,6 +13024,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13104,13 +13188,14 @@ dependencies = [
 
 [[package]]
 name = "web-async"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5414b65d9a5094649bb99987bb74db71febfdfa3677b7954a0a05c99d0424e8"
+checksum = "1ba1426dcf56093a94d9415ba4c016e45c1323679501e7309f1919ab32f08206"
 dependencies = [
  "tokio",
  "tracing",
  "wasm-bindgen-futures",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -13135,13 +13220,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-iroh"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34a91cf241951b8fe02ff216fdf16fc0a52b910568053652d546ded52399f77"
+checksum = "14c292c05ff2f4df8e582244a6a5f2ba89f4c13b1170ec5f59a727f9a4624baf"
 dependencies = [
  "bytes",
  "http",
  "iroh",
+ "kio",
  "n0-error 1.0.0",
  "n0-future",
  "tokio",
@@ -13153,13 +13239,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-noq"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e189796e9bf7d01cbd0af81ee8dbc49f9e836a1ccd2807539b174edcf88a422b"
+checksum = "56dfe08820de549204c3ab02e901c4a316616ba7daae26df4478a86f4a2d48cd"
 dependencies = [
  "bytes",
  "futures",
  "http",
+ "kio",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -13187,9 +13274,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9959d7a7db997953305c49e0db5087fb495614a186d1cdfa98c40f9a194dbe5d"
+checksum = "2a916df726e858e8e6cc21e852129f59e6277d3a01bb2254c0506dcf829fdd5d"
 dependencies = [
  "bytes",
 ]
@@ -13289,7 +13376,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "document-features",
  "hashbrown 0.16.1",
  "js-sys",
@@ -13346,7 +13433,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "bytemuck",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "document-features",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -13453,7 +13540,7 @@ dependencies = [
  "block",
  "bytemuck",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "core-graphics-types 0.2.0",
  "glow 0.16.0",
  "glutin_wgl_sys 0.6.1",
@@ -13573,7 +13660,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14039,7 +14126,7 @@ dependencies = [
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
@@ -14085,7 +14172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2879d2854d1a43e48f67322d4bd097afcb6eb8f8f775c8de0260a71aea1df1aa"
 dependencies = [
  "bitflags 2.11.1",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "cursor-icon",
  "dpi",
  "libc",
@@ -14428,6 +14515,17 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.62.2",
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ members = [
     "demos/opengl",
     "iroh-live-cli",
 ]
-# moq-media-dioxus is a workspace member but excluded from default builds.
-# It pulls ~224 additional deps (blitz-dom, vello, etc.) and is prototype-quality.
-# Build it explicitly with: cargo build -p moq-media-dioxus
+# moq-media-dioxus pulls ~224 additional deps (blitz-dom, vello, etc.) and is
+# prototype-quality, so it is left out of default-members: a bare `cargo build`
+# at the workspace root skips it. Note that `--workspace` overrides this and does
+# build it — CI passes `--workspace`, so it is compiled on every run.
+# Build it on its own with: cargo build -p moq-media-dioxus
 default-members = [
     "iroh-live",
     "iroh-live-relay",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,16 @@ lto = "thin"
 
 [workspace.dependencies]
 # External
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "portmapper", "fast-apple-datapath", "tls-aws-lc-rs"] }
+iroh = { version = "1.1.0", default-features = false, features = ["metrics", "portmapper", "fast-apple-datapath", "tls-aws-lc-rs"] }
 iroh-gossip = "0.101.0"
 iroh-tickets = "1.0.0"
 iroh-smol-kv = { version = "0.4.0", default-features = false }
-hang = "0.19.1"
-moq-lite = { package = "moq-net", version = "0.1.11" }
-moq-mux = "0.5.5"
-moq-relay = { version = "0.12.2", default-features = false }
-moq-native = { version = "0.17.1", default-features = false }
-web-transport-iroh = "0.6.0"
+hang = "0.20.6"
+moq-lite = { package = "moq-net", version = "0.2.14" }
+moq-mux = "0.9.9"
+moq-relay = { version = "0.14.12", default-features = false }
+moq-native = { version = "0.19.13", default-features = false }
+web-transport-iroh = "0.7.0"
 
 # In-repo crates
 iroh-live = { path = "iroh-live", default-features = false }

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ irl room <TICKET>
 
 ## Using iroh-live in Rust
 
-> **Note**: Right now iroh-live uses unreleased versions of several crates.
-> Downstream users should copy the `[patch.crates-io]` section of [Cargo.toml](Cargo.toml)
-> for now.
-
 The `iroh-live` crate provides the high-level API. A minimal publisher that
 captures camera and microphone, encodes them, and prints a ticket:
 

--- a/demos/pi-zero/src/publish.rs
+++ b/demos/pi-zero/src/publish.rs
@@ -91,7 +91,9 @@ pub(crate) async fn cmd_publish(opts: PublishOpts) -> n0_error::Result {
     // --- relay (optional) ---
     if let Some(relay_id) = opts.relay {
         let session = live.transport().connect(relay_id).await?;
-        session.publish(&opts.name, broadcast.producer().consume());
+        session
+            .publish(&opts.name, broadcast.producer().consume())
+            .map_err(|err| n0_error::anyerr!("failed to publish to relay: {err:#}"))?;
         tracing::info!(%relay_id, "published to relay");
     }
 

--- a/docs/architecture/transport.md
+++ b/docs/architecture/transport.md
@@ -23,7 +23,7 @@ state. Each session supports both publishing local broadcasts and
 subscribing to remote ones.
 
 `MoqProtocolHandler` implements iroh's `ProtocolHandler` trait, registered
-on a `Router` with the ALPN `moq-lite-03`. When the endpoint accepts an
+on a `Router` with the ALPN `moq-lite-04`. When the endpoint accepts an
 incoming connection with this ALPN, the handler completes the MoQ
 handshake and delivers the session to the actor.
 

--- a/docs/guide/moq.md
+++ b/docs/guide/moq.md
@@ -8,7 +8,7 @@
 
 ## Transport layer
 
-iroh-live uses [moq-lite](https://github.com/kixelated/moq), a Rust implementation of Media over QUIC, for its wire protocol. moq-lite carries media as named broadcasts, each containing one or more tracks. The connection is established over iroh's QUIC transport with the ALPN `moq-lite-03`.
+iroh-live uses [moq-lite](https://github.com/kixelated/moq), a Rust implementation of Media over QUIC, for its wire protocol. moq-lite carries media as named broadcasts, each containing one or more tracks. The connection is established over iroh's QUIC transport with the ALPN `moq-lite-04`.
 
 The `iroh-moq` crate wraps moq-lite with iroh endpoint management: it handles connection setup, protocol negotiation, and session lifecycle. Application code interacts with `MoqSession`, which exposes publish and subscribe operations on named broadcasts.
 
@@ -49,7 +49,7 @@ The `PacketSource` and `PacketSink` traits abstract over the transport, allowing
 
 A typical publish-subscribe flow:
 
-1. The publisher creates an iroh endpoint and starts accepting connections with the `moq-lite-03` ALPN.
+1. The publisher creates an iroh endpoint and starts accepting connections with the `moq-lite-04` ALPN.
 2. The publisher creates a `LocalBroadcast`, which produces a moq-lite `BroadcastProducer` with a catalog and media tracks.
 3. A subscriber connects to the publisher's endpoint address, negotiates a `MoqSession`, and subscribes to the broadcast by name.
 4. The subscriber receives the catalog, selects tracks, and begins consuming groups from each track.

--- a/iroh-live-cli/src/import.rs
+++ b/iroh-live-cli/src/import.rs
@@ -7,9 +7,8 @@ use std::{
     process::Stdio,
 };
 
-use bytes::BytesMut;
-use moq_lite::BroadcastProducer;
-use moq_mux::import::StreamFormat;
+use bytes::{Bytes, BytesMut};
+use moq_lite::broadcast::Producer as BroadcastProducer;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::{info, warn};
 
@@ -44,63 +43,95 @@ pub async fn open_input(
     }
 }
 
-/// Reads the file header and publishes the initial catalog to the producer.
+/// A byte-stream importer for one of the supported input formats.
 ///
-/// For fmp4 input this parses the moov box; for avc3 it reads until SPS/PPS
-/// are found. After this returns, consumers can subscribe to the catalog.
+/// moq-mux 0.9 split importers by multiplicity: a container that may publish
+/// several tracks (`fmp4`) versus a single codec on one track (`avc3`). They no
+/// longer share a type, so this enum keeps one `decode`/`finish` surface for the
+/// CLI, which only cares about feeding bytes.
+pub enum Importer {
+    /// A container that demuxes its own tracks (fMP4).
+    Container(moq_mux::import::ContainerStream),
+    /// A single codec on one reserved track (raw Annex-B H.264).
+    ///
+    /// Boxed: it is two orders of magnitude larger than the container variant.
+    Track(Box<moq_mux::import::TrackStream>),
+}
+
+impl Importer {
+    fn decode(&mut self, data: &[u8]) -> Result<(), moq_mux::Error> {
+        match self {
+            Self::Container(inner) => inner.decode(data),
+            Self::Track(inner) => inner.decode(data),
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), moq_mux::Error> {
+        match self {
+            Self::Container(inner) => inner.finish(),
+            Self::Track(inner) => inner.finish(),
+        }
+    }
+}
+
+/// Builds the importer and consumes enough input to surface an unusable stream.
+///
+/// The catalog is no longer published synchronously here: 0.9 resolves it inside
+/// the importer, as the container's header or the codec's first keyframe arrives.
+/// We still read one chunk so an empty or obviously wrong input fails before the
+/// broadcast is announced, which is what the old header loop was really for.
 pub async fn init_import(
     broadcast: &mut BroadcastProducer,
     format: ImportFormat,
     input: &mut Pin<Box<dyn AsyncRead + Send + 'static>>,
-) -> anyhow::Result<moq_mux::import::Stream> {
+) -> anyhow::Result<Importer> {
     let catalog = moq_mux::catalog::Producer::new(broadcast).unwrap();
-    let stream_format = match format {
-        ImportFormat::Fmp4 => StreamFormat::Fmp4,
-        ImportFormat::Avc3 => StreamFormat::Avc3,
+
+    let mut importer = match format {
+        ImportFormat::Fmp4 => Importer::Container(moq_mux::import::ContainerStream::new(
+            broadcast.clone(),
+            catalog.reserve(),
+            "fmp4",
+        )?),
+        ImportFormat::Avc3 => {
+            let request = broadcast.reserve_track("video")?;
+            Importer::Track(Box::new(moq_mux::import::TrackStream::new(
+                request,
+                catalog.reserve(),
+                moq_mux::import::Init::new("avc3", Bytes::new()),
+            )?))
+        }
     };
-    let mut decoder = moq_mux::import::Stream::new(broadcast.clone(), catalog, stream_format)?;
 
     let mut buffer = BytesMut::new();
-    let mut total_read = 0usize;
-    while !decoder.is_initialized() {
-        let n = input.read_buf(&mut buffer).await?;
-        if n == 0 {
-            if total_read == 0 {
-                anyhow::bail!("input is empty — expected {format:?} data on stdin or from file");
-            }
-            anyhow::bail!(
-                "reached end of input ({total_read} bytes) before finding a valid \
-                 {format:?} header. The file may not be fragmented MP4 — use \
-                 `--transcode` to re-mux with ffmpeg."
-            );
-        }
-        total_read += n;
-        decoder.decode_stream(&mut buffer).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to parse {format:?} header after {total_read} bytes: {e:#}. \
-                 If the file is a regular (non-fragmented) MP4, use `--transcode` \
-                 to re-mux it."
-            )
-        })?;
+    let n = input.read_buf(&mut buffer).await?;
+    if n == 0 {
+        anyhow::bail!("input is empty — expected {format:?} data on stdin or from file");
     }
+    importer.decode(&buffer).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to parse {format:?} input after {n} bytes: {e:#}. \
+             If the file is a regular (non-fragmented) MP4, use `--transcode` \
+             to re-mux it."
+        )
+    })?;
 
-    info!(
-        bytes_read = total_read,
-        "file header parsed, catalog published"
-    );
-    Ok(decoder)
+    info!(bytes_read = n, "input opened, importing");
+    Ok(importer)
 }
 
 /// Continues reading media data from `input` until EOF.
 pub async fn run_import(
-    mut decoder: moq_mux::import::Stream,
+    mut importer: Importer,
     mut input: Pin<Box<dyn AsyncRead + Send + 'static>>,
 ) -> anyhow::Result<()> {
     let mut buffer = BytesMut::new();
     while input.read_buf(&mut buffer).await? > 0 {
-        decoder.decode_stream(&mut buffer)?;
+        importer.decode(&buffer)?;
+        buffer.clear();
     }
-    decoder.finish()
+    importer.finish()?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/iroh-live-cli/src/publish.rs
+++ b/iroh-live-cli/src/publish.rs
@@ -8,7 +8,7 @@
 //! into a room, `--no-serve` disables incoming connections.
 
 use iroh_live::media::publish::LocalBroadcast;
-use moq_lite::{Broadcast, BroadcastProducer};
+use moq_lite::broadcast::{Info as Broadcast, Producer as BroadcastProducer};
 
 use crate::{
     args::PublishArgs,

--- a/iroh-live-cli/src/record.rs
+++ b/iroh-live-cli/src/record.rs
@@ -68,7 +68,7 @@ pub fn run(args: RecordArgs, rt: &tokio::runtime::Runtime) -> n0_error::Result {
 
         // Spawn video recording task.
         let video_task = if let Some(ref name) = video_name {
-            let (source, config) = broadcast.raw_video_track(name)?;
+            let (source, config) = broadcast.raw_video_track(name).await?;
             let ext = video_codec_extension(&config.codec);
             let path = output.with_extension(ext);
             println!("video: {name} ({}) -> {}", config.codec, path.display());
@@ -86,7 +86,7 @@ pub fn run(args: RecordArgs, rt: &tokio::runtime::Runtime) -> n0_error::Result {
 
         // Spawn audio recording task.
         let audio_task = if let Some(ref name) = audio_name {
-            let (source, config) = broadcast.raw_audio_track(name)?;
+            let (source, config) = broadcast.raw_audio_track(name).await?;
             let ext = audio_codec_extension(&config.codec);
             let path = output.with_extension(ext);
             println!("audio: {name} ({}) -> {}", config.codec, path.display());

--- a/iroh-live-cli/src/run.rs
+++ b/iroh-live-cli/src/run.rs
@@ -248,7 +248,7 @@ async fn run_session(config: RunConfig) -> n0_error::Result {
 
                     // Record video if available.
                     if let Ok(video_name) = catalog.select_video_rendition(Quality::Highest) {
-                        match broadcast.raw_video_track(&video_name) {
+                        match broadcast.raw_video_track(&video_name).await {
                             Ok((source, config)) => {
                                 let ext = video_codec_extension(&config.codec);
                                 let path = base.with_extension(ext);
@@ -268,7 +268,7 @@ async fn run_session(config: RunConfig) -> n0_error::Result {
 
                     // Record audio if available.
                     if let Ok(audio_name) = catalog.select_audio_rendition(Quality::Highest) {
-                        match broadcast.raw_audio_track(&audio_name) {
+                        match broadcast.raw_audio_track(&audio_name).await {
                             Ok((source, config)) => {
                                 let ext = audio_codec_extension(&config.codec);
                                 let path = base.with_extension(ext);

--- a/iroh-live-cli/src/transport.rs
+++ b/iroh-live-cli/src/transport.rs
@@ -6,7 +6,7 @@ use iroh_live::{
     rooms::{Room, RoomTicket},
     ticket::LiveTicket,
 };
-use moq_lite::BroadcastProducer;
+use moq_lite::broadcast::Producer as BroadcastProducer;
 use tracing::info;
 
 use crate::args::TransportArgs;
@@ -81,7 +81,7 @@ pub async fn publish_producer(
 async fn push_to_relay(
     live: &Live,
     name: &str,
-    consumer: moq_lite::BroadcastConsumer,
+    consumer: moq_lite::broadcast::Consumer,
     relay_addr: &str,
 ) -> anyhow::Result<()> {
     let id: iroh::EndpointId = relay_addr

--- a/iroh-live-cli/src/transport.rs
+++ b/iroh-live-cli/src/transport.rs
@@ -88,7 +88,9 @@ async fn push_to_relay(
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid relay address: {e}"))?;
     let session = live.transport().connect(id).await?;
-    session.publish(name, consumer);
+    session
+        .publish(name, consumer)
+        .map_err(|e| anyhow::anyhow!("failed to publish to relay: {e}"))?;
     info!(%relay_addr, "published to relay");
     Ok(())
 }

--- a/iroh-live-cli/src/ui.rs
+++ b/iroh-live-cli/src/ui.rs
@@ -525,13 +525,18 @@ impl RemoteControls {
         };
 
         // Video — respect rendition mode.
+        // Subscribing became async in moq-lite 0.2; this is a sync egui callback,
+        // so block on it the same way the Ctrl-C helper above does.
+        let handle = tokio::runtime::Handle::current();
         let video_result = match &self.rendition_mode {
-            RenditionMode::Fixed(name) => self
-                .broadcast
-                .video_rendition::<DynamicVideoDecoder>(&decode_config, name),
-            RenditionMode::Auto => self
-                .broadcast
-                .video_with(VideoOptions::default().playback(decode_config.clone())),
+            RenditionMode::Fixed(name) => handle.block_on(
+                self.broadcast
+                    .video_rendition::<DynamicVideoDecoder>(&decode_config, name),
+            ),
+            RenditionMode::Auto => handle.block_on(
+                self.broadcast
+                    .video_with(VideoOptions::default().playback(decode_config.clone())),
+            ),
         };
         match video_result {
             Ok(track) => {

--- a/iroh-live-relay/src/lib.rs
+++ b/iroh-live-relay/src/lib.rs
@@ -4,11 +4,7 @@
 //! connections. Adding auth is straightforward since MoQ supports token-based
 //! authentication.
 
-use std::{
-    net::SocketAddr,
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use axum::{extract::State, response::IntoResponse, routing::get};
 use clap::Args;
@@ -46,13 +42,13 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
     let mut server_config = moq_native::ServerConfig::default();
     server_config.bind = Some(config.bind.to_string());
     server_config.backend = Some(moq_native::QuicBackend::Noq);
-    server_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
+    server_config.quic.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
     // Self-signed TLS for dev mode. ACME/Let's Encrypt support is planned
     // but not yet implemented (see plans/relay-browser.md).
     server_config.tls.generate = vec!["localhost".to_string()];
 
     let mut client_config = moq_native::ClientConfig::default();
-    client_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
+    client_config.quic.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
 
     let iroh_secret = relay.iroh_secret_key()?;
     // Register the MoQ ALPNs so the endpoint accepts iroh-native MoQ clients
@@ -75,17 +71,21 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
         .bind()
         .await?;
 
+    // Cloned before `init` consumes the config: the auth client reuses the
+    // cluster client's TLS for outbound HTTP.
+    let client_tls = client_config.tls.clone();
     let server = server_config.init()?;
     let client = client_config.init()?;
     let (mut server, client) = (
-        server.with_iroh(Some(iroh_endpoint.clone())),
-        client.with_iroh(Some(iroh_endpoint.clone())),
+        server.with_iroh(iroh_endpoint.clone()),
+        client.with_iroh(iroh_endpoint.clone()),
     );
 
     tracing::info!(endpoint_id = %iroh_endpoint.id(), "iroh endpoint bound");
     println!("iroh endpoint: {}", iroh_endpoint.id());
 
-    let tls_info = server.tls_info();
+    // Hold the handle rather than the values: it tracks certificate hot reloads.
+    let certificates = server.certificates();
 
     // TODO: Implement auth (free for all atm)
     let mut auth_config = AuthConfig::default();
@@ -95,9 +95,9 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
         publish: prefixes,
         api: None,
     }));
-    let auth = auth_config.init().await?;
+    let auth = auth_config.init(&client_tls).await?;
 
-    let cluster = Cluster::new(ClusterConfig::default()).with_client(client);
+    let cluster = Cluster::new(ClusterConfig::default())?.with_client(client);
     let cluster_handle = cluster.clone();
     tokio::spawn(async move {
         cluster_handle.run().await.expect("cluster failed");
@@ -109,9 +109,7 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
         Some(Arc::new(pull::PullState::new(pull_live, cluster.clone())))
     };
 
-    let http_state = Arc::new(HttpState {
-        tls_info: tls_info.clone(),
-    });
+    let http_state = Arc::new(HttpState { certificates });
 
     let quic_addr = server.local_addr()?;
     let quic_port = quic_addr.port();
@@ -154,7 +152,7 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
     let mut conn_id = 0u64;
     while let Some(request) = server.accept().await {
         let transport = request.transport();
-        debug!(conn_id, transport, "accepted connection");
+        debug!(conn_id, ?transport, "accepted connection");
 
         let ticket = pull_state.as_ref().and_then(|_| {
             let name = extract_name_from_url(&request)?;
@@ -163,7 +161,7 @@ pub async fn run(config: RelayConfig) -> anyhow::Result<()> {
             debug!("parsed: {parsed:?}");
             parsed.ok()
         });
-        debug!(conn_id, transport, ?ticket, "parsed ticket");
+        debug!(conn_id, ?transport, ?ticket, "parsed ticket");
 
         let pull_clone = pull_state.clone();
         let conn = Connection {
@@ -230,7 +228,7 @@ impl RelayServer {
 }
 
 struct HttpState {
-    tls_info: Arc<RwLock<moq_native::tls::Info>>,
+    certificates: moq_native::tls::Certificates,
 }
 
 fn extract_name_from_url(request: &moq_native::Request) -> Option<String> {
@@ -244,8 +242,12 @@ fn extract_name_from_url(request: &moq_native::Request) -> Option<String> {
 }
 
 async fn serve_fingerprint(State(state): State<Arc<HttpState>>) -> impl IntoResponse {
-    let info = state.tls_info.read().expect("tls_info lock poisoned");
-    info.fingerprints.first().cloned().unwrap_or_default()
+    state
+        .certificates
+        .fingerprints()
+        .first()
+        .cloned()
+        .unwrap_or_default()
 }
 
 async fn serve_index() -> impl IntoResponse {

--- a/iroh-live-relay/src/pull.rs
+++ b/iroh-live-relay/src/pull.rs
@@ -28,6 +28,10 @@ pub(crate) struct PullState {
     /// duplicate concurrent connections to the same remote (TOCTOU guard).
     /// Entries are removed once the connection completes or fails.
     connecting: Arc<Mutex<HashMap<String, Arc<Notify>>>>,
+    /// Broadcasts this relay currently announces into the cluster, keyed by local
+    /// name. moq-lite 0.2 dropped `origin::Consumer::get_broadcast`, so presence is
+    /// tracked here instead; the handle also owns the forwarding task.
+    served: Arc<Mutex<HashMap<String, iroh_moq::AbortOnDropHandle<()>>>>,
 }
 
 impl PullState {
@@ -36,6 +40,7 @@ impl PullState {
             live,
             cluster,
             connecting: Arc::new(Mutex::new(HashMap::new())),
+            served: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -49,13 +54,7 @@ impl PullState {
         let local_name = ticket.to_string();
 
         // Fast path: broadcast already exists in the cluster.
-        if self
-            .cluster
-            .origin
-            .consume()
-            .get_broadcast(&local_name)
-            .is_some()
-        {
+        if self.served.lock().expect("lock").contains_key(&local_name) {
             tracing::debug!(
                 local_name = %local_name,
                 "pull: broadcast already available in cluster"
@@ -84,13 +83,7 @@ impl PullState {
                 notify.notified().await;
                 // The connecting task finished. Check whether the broadcast
                 // appeared in the cluster (success) or not (failure).
-                if self
-                    .cluster
-                    .origin
-                    .consume()
-                    .get_broadcast(&local_name)
-                    .is_some()
-                {
+                if self.served.lock().expect("lock").contains_key(&local_name) {
                     Ok(local_name)
                 } else {
                     anyhow::bail!("pull for ticket failed or was removed")
@@ -130,7 +123,12 @@ impl PullState {
             .await
             .map_err(|e| anyhow::anyhow!("failed to subscribe to broadcast: {e}"))?;
 
-        self.cluster.origin.publish_broadcast(local_name, consumer);
+        let handle = iroh_moq::announce_broadcast(&self.cluster.origin, local_name, consumer)
+            .map_err(|e| anyhow::anyhow!("failed to announce broadcast locally: {e}"))?;
+        self.served
+            .lock()
+            .expect("lock")
+            .insert(local_name.to_owned(), handle);
 
         tracing::info!(
             local_name = %local_name,

--- a/iroh-live-relay/src/pull.rs
+++ b/iroh-live-relay/src/pull.rs
@@ -30,8 +30,8 @@ pub(crate) struct PullState {
     connecting: Arc<Mutex<HashMap<String, Arc<Notify>>>>,
     /// Broadcasts this relay currently announces into the cluster, keyed by local
     /// name. moq-lite 0.2 dropped `origin::Consumer::get_broadcast`, so presence is
-    /// tracked here instead; the handle also owns the forwarding task.
-    served: Arc<Mutex<HashMap<String, iroh_moq::AbortOnDropHandle<()>>>>,
+    /// tracked here instead; holding the announcement also keeps it served.
+    served: Arc<Mutex<HashMap<String, iroh_moq::BroadcastAnnouncement>>>,
 }
 
 impl PullState {

--- a/iroh-live-relay/tests/relay_bridge.rs
+++ b/iroh-live-relay/tests/relay_bridge.rs
@@ -12,7 +12,7 @@ use std::{sync::OnceLock, time::Duration};
 
 use iroh::address_lookup::MemoryLookup;
 use moq_media::publish::VideoInput;
-use moq_native::moq_net::{Origin, Track};
+use moq_native::moq_net::{Origin, Timestamp, broadcast::Route, track};
 use moq_relay::{PublicConfig, PublicDetailed};
 use serial_test::serial;
 
@@ -39,10 +39,10 @@ impl TestRelay {
         server_config.bind = Some("[::]:0".parse().unwrap());
         server_config.backend = Some(moq_native::QuicBackend::Noq);
         server_config.tls.generate = vec!["localhost".into()];
-        server_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
+        server_config.quic.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
 
         let mut client_config = moq_native::ClientConfig::default();
-        client_config.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
+        client_config.quic.max_streams = Some(moq_relay::DEFAULT_MAX_STREAMS);
 
         // Build the relay's iroh endpoint with Minimal preset + MemoryLookup
         // instead of IrohEndpointConfig (which uses presets::N0 and real DNS
@@ -63,8 +63,8 @@ impl TestRelay {
 
         shared_lookup().add_endpoint_info(iroh.addr());
         let iroh_id = Some(iroh.id().to_string());
-        let iroh = Some(iroh);
 
+        let client_tls = client_config.tls.clone();
         let server = server_config.init().expect("init server");
         let client = client_config.init().expect("init client");
 
@@ -81,10 +81,11 @@ impl TestRelay {
             publish: prefixes,
             api: None,
         }));
-        let auth = auth_config.init().await.expect("init auth");
+        let auth = auth_config.init(&client_tls).await.expect("init auth");
 
-        let cluster =
-            moq_relay::Cluster::new(moq_relay::ClusterConfig::default()).with_client(client);
+        let cluster = moq_relay::Cluster::new(moq_relay::ClusterConfig::default())
+            .expect("cluster")
+            .with_client(client);
         let cluster_handle = cluster.clone();
         tokio::spawn(async move {
             cluster_handle.run().await.expect("cluster failed");
@@ -128,10 +129,16 @@ async fn noq_publish_noq_subscribe() {
 
     // Publisher
     let pub_origin = Origin::random().produce();
-    let mut broadcast = pub_origin.create_broadcast("test").expect("create bc");
-    let mut track = broadcast.create_track(Track::new("video")).expect("track");
+    let mut broadcast = pub_origin
+        .create_broadcast("test", Route::announced())
+        .expect("create bc");
+    let mut track = broadcast
+        .create_track("video", track::Info::default())
+        .expect("track");
     let mut group = track.append_group().expect("group");
-    group.write_frame(b"hello-noq".as_ref()).expect("write");
+    group
+        .write_frame(Timestamp::from_millis(0).unwrap(), b"hello-noq".as_ref())
+        .expect("write");
     group.finish().expect("finish");
 
     let mut pub_cfg = moq_native::ClientConfig::default();
@@ -141,7 +148,7 @@ async fn noq_publish_noq_subscribe() {
     let pub_url: url::Url = format!("https://localhost:{}", relay.noq_addr.port())
         .parse()
         .unwrap();
-    let pub_client = pub_client.with_publish(pub_origin.consume());
+    let pub_client = pub_client.with_publisher(pub_origin.consume());
     let _pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url))
         .await
         .expect("timeout")
@@ -149,7 +156,7 @@ async fn noq_publish_noq_subscribe() {
 
     // Subscriber
     let sub_origin = Origin::random().produce();
-    let mut announcements = sub_origin.consume();
+    let mut announcements = sub_origin.consume().announced();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
     sub_cfg.backend = Some(moq_native::QuicBackend::Noq);
@@ -157,19 +164,23 @@ async fn noq_publish_noq_subscribe() {
     let sub_url: url::Url = format!("https://localhost:{}", relay.noq_addr.port())
         .parse()
         .unwrap();
-    let sub_client = sub_client.with_consume(sub_origin);
+    let sub_client = sub_client.with_subscriber(sub_origin);
     let _sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url))
         .await
         .expect("timeout")
         .expect("connect");
 
-    let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+    let announce = tokio::time::timeout(TIMEOUT, announcements.next())
         .await
         .expect("timeout")
         .expect("closed");
-    assert_eq!(path.as_str(), "test");
-    let bc = bc.expect("announce");
-    let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("sub");
+    assert_eq!(announce.path.as_str(), "test");
+    let bc = announce.broadcast.expect("announce");
+    let track_sub = bc.track("video").expect("sub");
+    let mut track_sub = tokio::time::timeout(TIMEOUT, track_sub.subscribe(None))
+        .await
+        .expect("timeout")
+        .expect("subscribe");
     let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
         .await
         .expect("timeout")
@@ -180,7 +191,7 @@ async fn noq_publish_noq_subscribe() {
         .expect("timeout")
         .expect("err")
         .expect("closed");
-    assert_eq!(&*frame, b"hello-noq");
+    assert_eq!(&frame.payload[..], b"hello-noq");
 
     relay.server_handle.abort();
 }
@@ -240,7 +251,7 @@ async fn iroh_publish_iroh_subscribe() {
         .expect("subscribe");
 
     assert!(sub.broadcast().has_video());
-    let mut video = sub.broadcast().video().expect("video track");
+    let mut video = sub.broadcast().video().await.expect("video track");
     let frame = tokio::time::timeout(Duration::from_secs(10), video.next_frame())
         .await
         .expect("timeout")
@@ -272,24 +283,31 @@ async fn noq_publish_iroh_subscribe() {
     // ── Publisher (noq, simulating browser) ──
     // Publish a broadcast with a hang-compatible catalog and video track.
     let pub_origin = Origin::random().produce();
-    let mut broadcast = pub_origin.create_broadcast("browser-stream").expect("bc");
+    let mut broadcast = pub_origin
+        .create_broadcast("browser-stream", Route::announced())
+        .expect("bc");
 
     // hang catalog format: renditions keyed by track name
     let mut catalog_track = broadcast
-        .create_track(Track::new("catalog.json"))
+        .create_track("catalog.json", track::Info::default())
         .expect("catalog");
     let catalog_json =
         br#"{"video":{"renditions":{"video/h264":{"codec":"avc1.64001f","codedWidth":320,"codedHeight":240,"bitrate":500000,"framerate":30}}}}"#;
     let mut group = catalog_track.append_group().expect("group");
-    group.write_frame(catalog_json.as_ref()).expect("write");
+    group
+        .write_frame(Timestamp::from_millis(0).unwrap(), catalog_json.as_ref())
+        .expect("write");
     group.finish().expect("finish");
 
     let mut video_track = broadcast
-        .create_track(Track::new("video/h264"))
+        .create_track("video/h264", track::Info::default())
         .expect("video");
     let mut vgroup = video_track.append_group().expect("group");
     vgroup
-        .write_frame(b"keyframe-data".as_ref())
+        .write_frame(
+            Timestamp::from_millis(0).unwrap(),
+            b"keyframe-data".as_ref(),
+        )
         .expect("write");
     vgroup.finish().expect("finish");
 
@@ -300,7 +318,7 @@ async fn noq_publish_iroh_subscribe() {
     let pub_url: url::Url = format!("https://localhost:{}", relay.noq_addr.port())
         .parse()
         .unwrap();
-    let pub_client = pub_client.with_publish(pub_origin.consume());
+    let pub_client = pub_client.with_publisher(pub_origin.consume());
     let _pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url))
         .await
         .expect("timeout")
@@ -431,16 +449,14 @@ async fn pull_remote_broadcast_via_ticket() {
     // Inject into the relay's cluster under the full ticket string (matches
     // what the browser subscribes to via `?name=iroh-live:ADDR/broadcast`).
     let local_name = ticket.to_string();
-    relay
-        .cluster
-        .origin
-        .publish_broadcast(&local_name, consumer);
+    let _served = iroh_moq::announce_broadcast(&relay.cluster.origin, &local_name, consumer)
+        .expect("announce pulled broadcast");
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // ── Subscriber (noq, simulating browser) ──
     let sub_origin = Origin::random().produce();
-    let mut announcements = sub_origin.consume();
+    let mut announcements = sub_origin.consume().announced();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
     sub_cfg.backend = Some(moq_native::QuicBackend::Noq);
@@ -448,17 +464,18 @@ async fn pull_remote_broadcast_via_ticket() {
     let sub_url: url::Url = format!("https://localhost:{}", relay.noq_addr.port())
         .parse()
         .unwrap();
-    let sub_client = sub_client.with_consume(sub_origin);
+    let sub_client = sub_client.with_subscriber(sub_origin);
     let _sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url))
         .await
         .expect("timeout")
         .expect("connect");
 
     // Should see the pulled broadcast announced.
-    let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+    let announce = tokio::time::timeout(TIMEOUT, announcements.next())
         .await
         .expect("announce timeout — pull mode may not work")
         .expect("closed");
+    let (path, bc) = (announce.path, announce.broadcast);
     // The pulled broadcast is published under the full ticket string.
     assert!(
         path.as_str().starts_with("iroh-live:"),
@@ -467,9 +484,11 @@ async fn pull_remote_broadcast_via_ticket() {
     let bc = bc.expect("announce");
 
     // Subscribe to a track and verify data arrives.
-    let mut catalog_track = bc
-        .subscribe_track(&Track::new("catalog.json"))
-        .expect("catalog sub");
+    let catalog_track = bc.track("catalog.json").expect("catalog sub");
+    let mut catalog_track = tokio::time::timeout(TIMEOUT, catalog_track.subscribe(None))
+        .await
+        .expect("catalog subscribe timeout")
+        .expect("catalog subscribe");
     let mut group = tokio::time::timeout(TIMEOUT, catalog_track.next_group())
         .await
         .expect("catalog group timeout")
@@ -534,7 +553,7 @@ async fn iroh_publish_noq_subscribe() {
 
     // Subscriber (noq)
     let sub_origin = Origin::random().produce();
-    let mut announcements = sub_origin.consume();
+    let mut announcements = sub_origin.consume().announced();
     let mut sub_cfg = moq_native::ClientConfig::default();
     sub_cfg.tls.disable_verify = Some(true);
     sub_cfg.backend = Some(moq_native::QuicBackend::Noq);
@@ -542,16 +561,17 @@ async fn iroh_publish_noq_subscribe() {
     let sub_url: url::Url = format!("https://localhost:{}", relay.noq_addr.port())
         .parse()
         .unwrap();
-    let sub_client = sub_client.with_consume(sub_origin);
+    let sub_client = sub_client.with_subscriber(sub_origin);
     let _sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url))
         .await
         .expect("timeout")
         .expect("connect");
 
-    let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+    let announce = tokio::time::timeout(TIMEOUT, announcements.next())
         .await
         .expect("announce timeout — iroh→noq bridging may not work")
         .expect("closed");
+    let (path, bc) = (announce.path, announce.broadcast);
     assert_eq!(path.as_str(), "cli-stream");
     let _bc = bc.expect("announce");
     tracing::info!("noq subscriber received cli-stream announcement");

--- a/iroh-live-relay/web/.gitignore
+++ b/iroh-live-relay/web/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 bun.lock
 /dist
-/package-lock.json

--- a/iroh-live-relay/web/package-lock.json
+++ b/iroh-live-relay/web/package-lock.json
@@ -1,0 +1,2193 @@
+{
+  "name": "iroh-live-relay-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iroh-live-relay-web",
+      "dependencies": {
+        "@moq/publish": "=0.4.5",
+        "@moq/watch": "=0.5.2"
+      },
+      "devDependencies": {
+        "solid-element": "^1.9.1",
+        "solid-js": "^1.9.10",
+        "typescript": "^5.9.2",
+        "vite": "^7.3.1",
+        "vite-plugin-solid": "^2.11.10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kixelated/libavjs-webcodecs-polyfill": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@kixelated/libavjs-webcodecs-polyfill/-/libavjs-webcodecs-polyfill-0.5.5.tgz",
+      "integrity": "sha512-Q1zgnTMMQ2F7IE9ylx3C1XzVbg5vYN18jiDINO5U3kNPBOHdYuUlJsMhtBoqr1M6ocLtoiqdHmLs7tHFgrw5KA==",
+      "license": "0BSD",
+      "dependencies": {
+        "@libav.js/types": "^6.7.7",
+        "@ungap/global-this": "^0.4.4"
+      }
+    },
+    "node_modules/@libav.js/types": {
+      "version": "6.10.9",
+      "resolved": "https://registry.npmjs.org/@libav.js/types/-/types-6.10.9.tgz",
+      "integrity": "sha512-AdngxD/VO8OI6/w7wlJC77kuFcsSvCUuo2RuC6gGeSW2DEvbzgBo2JtFLV6UWZp/tRNZhKm6jS0Tv8gwCKBHLg==",
+      "license": "LGPL-2.1"
+    },
+    "node_modules/@libav.js/variant-opus-af": {
+      "version": "6.10.9",
+      "resolved": "https://registry.npmjs.org/@libav.js/variant-opus-af/-/variant-opus-af-6.10.9.tgz",
+      "integrity": "sha512-yULJUCQIHDtwDPbT38t9pP/7EGgqwynVcOau46hZjtCe8TWMp67DTi2X0Emr2M4Ci3nzxNPf25IzO+IXSmHDBg==",
+      "license": "LGPL-2.1"
+    },
+    "node_modules/@moq/flate": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@moq/flate/-/flate-0.1.2.tgz",
+      "integrity": "sha512-/vtXPGZQ0skmj9/HQlz1DoTJLlnT8/m2QkguNp8R5J68cwa8NtrUr9J89xqQwVCdi4Ybqy71d03bJU2P7i9uyA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "pako": "^3.0.1"
+      }
+    },
+    "node_modules/@moq/hang": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@moq/hang/-/hang-0.4.2.tgz",
+      "integrity": "sha512-SfSKvDUqrOymjUX9oprEmTpsq4kfBjRcL70MdurK9ntBF/0gLwIXPqSpUF5tc1KN+lwiBqBjYBDln8GNsv9pIA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
+        "@libav.js/variant-opus-af": "^6.9.8",
+        "@moq/json": "^0.3.2",
+        "@moq/loc": "^0.2.2",
+        "@moq/net": "^0.3.3",
+        "@moq/signals": "^0.2.2",
+        "@svta/cml-iso-bmff": "^1.0.4",
+        "@svta/cml-utils": "1.6.0",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@moq/json": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@moq/json/-/json-0.3.2.tgz",
+      "integrity": "sha512-6ewNcj5u0XR4EwbJyrZjhEs5PnwzU95YFga5ti/w1ysAHvPDyC7jYZssPH9dxZ9mJX/v60vz8d36RDeSXI/4/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/flate": "^0.1.2",
+        "@moq/net": "^0.3.2",
+        "@moq/signals": "^0.2.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@moq/loc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@moq/loc/-/loc-0.2.2.tgz",
+      "integrity": "sha512-J1M+G0+naOB7hch4W9722kWnHHSwYXDvuBlcDQS5PSYuAFo9x53ULRpU64/vSxAvjvAs1Y+ek+8iRNl0DdDxRQ==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/net": "^0.3.2"
+      }
+    },
+    "node_modules/@moq/msf": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@moq/msf/-/msf-0.2.1.tgz",
+      "integrity": "sha512-nwSGupyfMoDQVJw0g349er4SlrReu+OC/oiAWyxH6KDpgbAu2vuhIKN6JcyOWsS3EIHy6G4zfizMme8yIFYqGQ==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/net": "^0.3.2",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@moq/net": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.3.3.tgz",
+      "integrity": "sha512-L98/klurH5I272SfwxNWKAT917N8mjFRrh+AVcWdpglj1IdygeUc9cU1Esck8yn3rGprurszWRxk45pUvd3MsQ==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/qmux": "^0.3.3",
+        "@moq/signals": "^0.2.2",
+        "async-mutex": "^0.5.0",
+        "bowser": "^2.14.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@moq/publish": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@moq/publish/-/publish-0.4.5.tgz",
+      "integrity": "sha512-RlN/X+FaJZQFd1M72fuIFabIqtNlgx9lA4kqr0HFhGLije1EfLIbJINOucI7r3T18JuQz6LY4hcjOj8acO9Eog==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/hang": "^0.4.2",
+        "@moq/net": "^0.3.3",
+        "@moq/signals": "^0.2.2"
+      }
+    },
+    "node_modules/@moq/qmux": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@moq/qmux/-/qmux-0.3.3.tgz",
+      "integrity": "sha512-Ez1GCVwpyNGB0eWvhKIXOjXrfRlMdmO0lpJ7gqInZFzsOsYTyML0WRgh24Itczp9Kev0CXsUA/K+XrGs1dRKUA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/web-socket-stream": "^0.1.1"
+      }
+    },
+    "node_modules/@moq/signals": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@moq/signals/-/signals-0.2.2.tgz",
+      "integrity": "sha512-BnVp70shiD+HcEM612Ra8tKwnneV7m9gzIFJrRCRVcZW2L+t9P7pVpd0pzj8tydfmInKh97SBPlkaaU+rEM2ng==",
+      "license": "(MIT OR Apache-2.0)",
+      "peerDependencies": {
+        "@types/react": "^19.2.17",
+        "react": "^19.2.8",
+        "solid-js": "^1.9.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@moq/watch": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@moq/watch/-/watch-0.5.2.tgz",
+      "integrity": "sha512-iBzQpkAxzTHDtWvjb3pRz+VfjDb+1yXM/x2f9PbKq5kPBI5LyBnqPwpZdjpF7RPIGyXEmRfcyQTV7LATdF40Hw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/hang": "^0.4.2",
+        "@moq/msf": "^0.2.1",
+        "@moq/net": "^0.3.3",
+        "@moq/signals": "^0.2.2"
+      }
+    },
+    "node_modules/@moq/web-socket-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@moq/web-socket-stream/-/web-socket-stream-0.1.1.tgz",
+      "integrity": "sha512-VKi/GE/CLqmbEZlgNbBLbAFk2pQTxT+KUD2DjCSoxqZxbS3KBe5BBZ0m3fila4fEGyll2JT5MmgEyVr4zkZEVA==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@svta/cml-iso-bmff": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.5.tgz",
+      "integrity": "sha512-9JM/i5q81/ckFb0V5z2gESX4ICyoBOCwYhLmltPgQXNo55DenORjfY8czgSdlGuMOKxyX1yvwe/OpY4twmqT2g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.6.0"
+      }
+    },
+    "node_modules/@svta/cml-utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.6.0.tgz",
+      "integrity": "sha512-h8jd5Y0nrr8wHWkI7XB03Denxy6QR7dgROxchZ2S0VQ4PFINrIu6J0k9N1IGHmtJnJjG3ttszsJd4LS5V/DqcA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/global-this": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
+      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==",
+      "license": "ISC"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.10",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.10.tgz",
+      "integrity": "sha512-lxve6Y02YiZTldB7efKpnbf1BH00XCFZNYYW235jSGsYaJNFtHrYlKV6/O+miHbjqpIr9FTe5+0no4hofAMbfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.15.tgz",
+      "integrity": "sha512-GBmg1OiPb+OwcH51XbDAKPtvrPfQW7rCJTJxcp8+yhtWwN+kqnbEJk2SgVybd+uhTxTKAvjaFyiQSr/eUZBwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.10"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.15"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/component-register": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/component-register/-/component-register-0.8.8.tgz",
+      "integrity": "sha512-djhwcxjY+X9dacaYUEOkOm7tda8uOEDiMDigWysu3xv54M8o6XDlsjR1qt5Y8QLGiKg51fqXFIR2HUTmt9ys0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge-anything": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
+      "integrity": "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pako": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.1.tgz",
+      "integrity": "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.6.tgz",
+      "integrity": "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
+    "node_modules/solid-element": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/solid-element/-/solid-element-1.9.2.tgz",
+      "integrity": "sha512-+6bK9YGAf47lrwWyTFXUVKCkKTkof3bn6yxknHJPAE5MGSCvx4DJH1KE3ltUjIXeDWhS2gU5yjpynkH709+Xag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-register": "^0.8.7"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.9.14"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.15.tgz",
+      "integrity": "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.4",
+        "seroval-plugins": "~1.5.4"
+      }
+    },
+    "node_modules/solid-refresh": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/solid-refresh/-/solid-refresh-0.6.3.tgz",
+      "integrity": "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/types": "^7.23.6"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-solid": {
+      "version": "2.11.14",
+      "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.14.tgz",
+      "integrity": "sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.3",
+        "@types/babel__core": "^7.20.4",
+        "babel-preset-solid": "^1.8.4",
+        "merge-anything": "^5.1.7",
+        "solid-refresh": "^0.6.3",
+        "vitefu": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0",
+        "solid-js": "^1.7.2",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@testing-library/jest-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/iroh-live-relay/web/package.json
+++ b/iroh-live-relay/web/package.json
@@ -7,8 +7,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@moq/watch": "=0.2.8",
-    "@moq/publish": "=0.2.4"
+    "@moq/watch": "=0.5.2",
+    "@moq/publish": "=0.4.5"
   },
   "devDependencies": {
     "solid-js": "^1.9.10",

--- a/iroh-live/examples/split.rs
+++ b/iroh-live/examples/split.rs
@@ -554,7 +554,8 @@ impl SubscribeView {
             ..Default::default()
         };
         let opts = moq_media::subscribe::VideoOptions::default().playback(decode_config);
-        match self.broadcast.video_with(opts) {
+        let handle = tokio::runtime::Handle::current();
+        match handle.block_on(self.broadcast.video_with(opts)) {
             Ok(track) => {
                 info!(
                     rendition = track.rendition(),
@@ -571,7 +572,6 @@ impl SubscribeView {
 
         // Resubscribe audio. The old AudioTrack is dropped, stopping its
         // decoder thread, before starting a fresh one from the new catalog.
-        let handle = tokio::runtime::Handle::current();
         match handle.block_on(self.broadcast.audio(&self.audio_ctx)) {
             Ok(track) => {
                 info!("subscriber: resubscribed to audio");
@@ -643,10 +643,11 @@ impl SubscribeView {
                                 backend: self.backend,
                                 ..Default::default()
                             };
-                            match self
-                                .broadcast
-                                .video_rendition::<DynamicVideoDecoder>(&decode_config, name)
-                            {
+                            let handle = tokio::runtime::Handle::current();
+                            match handle.block_on(
+                                self.broadcast
+                                    .video_rendition::<DynamicVideoDecoder>(&decode_config, name),
+                            ) {
                                 Ok(track) => {
                                     self.video = Some(self.make_video_view(ctx, track));
                                 }

--- a/iroh-live/src/call.rs
+++ b/iroh-live/src/call.rs
@@ -80,7 +80,9 @@ impl Call {
     /// Auto-wires stats recording and network signal production on the
     /// connection, so callers do not need to do this manually.
     async fn setup(mut session: MoqSession, local: LocalBroadcast) -> Result<Self, CallError> {
-        session.publish(CALL_BROADCAST_NAME, local.consume());
+        session
+            .publish(CALL_BROADCAST_NAME, local.consume())
+            .map_err(|err| CallError::ConnectionFailed(n0_error::anyerr!("{err:#}")))?;
 
         let consumer = session
             .subscribe(CALL_BROADCAST_NAME)

--- a/iroh-live/src/live.rs
+++ b/iroh-live/src/live.rs
@@ -205,7 +205,7 @@ impl Live {
         self.moq.publish(name, broadcast.producer()).await
     }
 
-    /// Registers a raw [`BroadcastProducer`](moq_lite::BroadcastProducer).
+    /// Registers a raw [`BroadcastProducer`](moq_lite::broadcast::Producer).
     ///
     /// Prefer [`publish`](Self::publish) with a [`LocalBroadcast`] for the
     /// common case. This method exists for situations where you construct the
@@ -215,7 +215,7 @@ impl Live {
     pub async fn publish_broadcast_producer(
         &self,
         name: impl ToString,
-        producer: moq_lite::BroadcastProducer,
+        producer: moq_lite::broadcast::Producer,
     ) -> Result<()> {
         self.moq.publish(name, producer).await
     }

--- a/iroh-live/src/rooms.rs
+++ b/iroh-live/src/rooms.rs
@@ -10,7 +10,7 @@ use iroh::{EndpointId, SecretKey};
 use iroh_gossip::Gossip;
 use iroh_moq::MoqSession;
 use iroh_smol_kv::{ExpiryConfig, Filter, SignedValue, Subscribe, SubscribeMode, WriteScope};
-use moq_lite::BroadcastProducer;
+use moq_lite::broadcast::Producer as BroadcastProducer;
 use moq_media::{chat::ChatMessage, subscribe::RemoteBroadcast};
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr};
 use n0_future::{FuturesUnordered, StreamExt, task::AbortOnDropHandle};

--- a/iroh-live/src/rooms.rs
+++ b/iroh-live/src/rooms.rs
@@ -403,11 +403,17 @@ impl Actor {
                             let closed_fut = broadcast.closed();
 
                             // Spawn a chat subscriber task if the broadcast has a chat track.
-                            if let Some(mut chat_sub) = broadcast.chat() {
-                                self.chat_messages.push(Box::pin(async move {
-                                    let msg = chat_sub.recv().await;
-                                    (remote, msg, chat_sub)
-                                }));
+                            match broadcast.chat().await {
+                                Ok(Some(mut chat_sub)) => {
+                                    self.chat_messages.push(Box::pin(async move {
+                                        let msg = chat_sub.recv().await;
+                                        (remote, msg, chat_sub)
+                                    }));
+                                }
+                                Ok(None) => {}
+                                Err(err) => {
+                                    warn!(broadcast=%id, "failed to subscribe to chat: {err:#}")
+                                }
                             }
 
                             if self.event_tx.send(RoomEvent::BroadcastSubscribed { session: Box::new(session), broadcast: Box::new(broadcast) }).await.is_err() {

--- a/iroh-live/src/rooms/publisher.rs
+++ b/iroh-live/src/rooms/publisher.rs
@@ -1,4 +1,4 @@
-use moq_lite::BroadcastProducer;
+use moq_lite::broadcast::Producer as BroadcastProducer;
 use moq_media::{
     audio_backend::AudioBackend,
     publish::{PublishCaptureController, PublishOpts, PublishUpdateError},

--- a/iroh-live/tests/e2e.rs
+++ b/iroh-live/tests/e2e.rs
@@ -269,7 +269,7 @@ async fn adaptive_rendition_switching() {
     };
 
     // Create a regular VideoTrack and enable adaptation on it.
-    let mut track = remote.video().expect("failed to create video track");
+    let mut track = remote.video().await.expect("failed to create video track");
     track
         .enable_adaptation(remote.clone(), signals_rx, config, DecodeConfig::default())
         .expect("failed to enable adaptation");
@@ -422,6 +422,7 @@ async fn call_dial_accept() {
     let mut caller_video = caller_call
         .remote()
         .video()
+        .await
         .expect("caller: failed to create video track");
     let mut prev_ts = None;
     for i in 0..3 {
@@ -446,6 +447,7 @@ async fn call_dial_accept() {
     let mut callee_video = callee_call
         .remote()
         .video()
+        .await
         .expect("callee: failed to create video track");
     let mut prev_ts = None;
     for i in 0..3 {

--- a/iroh-live/tests/patchbay.rs
+++ b/iroh-live/tests/patchbay.rs
@@ -1109,6 +1109,7 @@ async fn adaptive_downgrade_upgrade_under_real_loss() {
     let decode_config = patchbay_decode();
     let mut track = remote
         .video_with(VideoOptions::default().playback(decode_config.clone()))
+        .await
         .expect("video track");
     track
         .enable_adaptation(remote.clone(), signals_rx, config, decode_config)
@@ -1516,7 +1517,9 @@ async fn video_ready_with_patchbay_decode(
     remote: &moq_media::subscribe::RemoteBroadcast,
 ) -> std::result::Result<moq_media::subscribe::VideoTrack, n0_error::AnyError> {
     remote.ready().await;
-    remote.video_with(VideoOptions::default().playback(patchbay_decode()))
+    remote
+        .video_with(VideoOptions::default().playback(patchbay_decode()))
+        .await
 }
 
 async fn wait_for_audio_beeps(
@@ -1606,6 +1609,7 @@ async fn av_sync_at_latency(latency_ms: u32, jitter_ms: u32) {
         fixture
             .remote
             .video_with(VideoOptions::default().playback(patchbay_decode()))
+            .await
     })
     .await
     .expect("video timeout")
@@ -1736,6 +1740,7 @@ async fn av_sync_recovery_after_blackout() {
         fixture
             .remote
             .video_with(VideoOptions::default().playback(patchbay_decode()))
+            .await
     })
     .await
     .expect("video timeout")
@@ -1887,6 +1892,7 @@ async fn av_sync_latency_spike_recovery() {
         fixture
             .remote
             .video_with(VideoOptions::default().playback(patchbay_decode()))
+            .await
     })
     .await
     .expect("video timeout")
@@ -2037,6 +2043,7 @@ async fn av_sync_sustained_loss() {
         fixture
             .remote
             .video_with(VideoOptions::default().playback(patchbay_decode()))
+            .await
     })
     .await
     .expect("video timeout")

--- a/iroh-moq/README.md
+++ b/iroh-moq/README.md
@@ -36,4 +36,4 @@ let mut session = moq.connect(remote_addr).await?;
 let consumer = session.subscribe("my-stream").await?;
 ```
 
-The ALPN is `moq-lite-03`, matching the moq-lite protocol version.
+The ALPN is `moq-lite-04`, matching the moq-lite protocol version.

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -21,11 +21,10 @@ use moq_lite::{
     origin::{Consumer as OriginConsumer, Producer as OriginProducer},
 };
 use n0_error::{AnyError, Result, StdResultExt, anyerr, e, stack_error};
-pub use n0_future::task::AbortOnDropHandle;
 use n0_future::{
     FuturesUnordered, StreamExt,
     boxed::BoxFuture,
-    task::{JoinSet, spawn},
+    task::{AbortOnDropHandle, JoinSet, spawn},
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -264,21 +263,26 @@ impl IncomingSession {
 pub struct MoqSession {
     wt_session: web_transport_iroh::Session,
     _moq_session: Arc<moq_lite::Session>,
-    _driver: Arc<AbortOnDropHandle<()>>,
+    _driver: Arc<AbortOnDropHandle<moq_lite::Result<()>>>,
     forwards: Forwards,
     publish: OriginProducer,
     subscribe: OriginConsumer,
 }
 
-/// Live forwarders for the broadcasts this session announces, keyed by name.
+/// Live announcements for the broadcasts this session serves, keyed by name.
+type Forwards = Arc<std::sync::Mutex<HashMap<String, BroadcastAnnouncement>>>;
+
+/// An announced broadcast, served for as long as this value is held.
 ///
-/// Dropping a handle aborts its forwarder, which finishes the announced broadcast.
-type Forwards = Arc<std::sync::Mutex<HashMap<String, AbortOnDropHandle<()>>>>;
+/// Dropping it stops serving and finishes the broadcast, so subscribers see a clean
+/// end rather than a dropped producer.
+#[derive(Debug)]
+#[must_use = "dropping this stops serving the announced broadcast"]
+pub struct BroadcastAnnouncement {
+    _task: AbortOnDropHandle<()>,
+}
 
 /// Announces `upstream` on `origin` under `name` and serves it in the background.
-///
-/// The returned handle owns the forwarding task: drop it to stop serving and finish
-/// the announced broadcast.
 ///
 /// This replaces moq-lite 0.1's `origin::Producer::publish_broadcast(name, consumer)`.
 /// See [`forward_broadcast`] for why the work is needed at all.
@@ -286,11 +290,11 @@ pub fn announce_broadcast(
     origin: &OriginProducer,
     name: &str,
     upstream: BroadcastConsumer,
-) -> Result<AbortOnDropHandle<()>, moq_lite::Error> {
+) -> Result<BroadcastAnnouncement, moq_lite::Error> {
     let announced = origin.create_broadcast(name, moq_lite::broadcast::Route::announced())?;
-    Ok(AbortOnDropHandle::new(spawn(forward_broadcast(
-        announced, upstream,
-    ))))
+    Ok(BroadcastAnnouncement {
+        _task: AbortOnDropHandle::new(spawn(forward_broadcast(announced, upstream))),
+    })
 }
 
 /// Announces `upstream` to the remote peer under `name` and serves it.
@@ -319,7 +323,7 @@ pub(crate) async fn forward_broadcast(
         let name = request.name().to_string();
         match upstream.track(&name) {
             Ok(track) => {
-                tracks.spawn(forward_track(track, request.accept(None)));
+                tracks.spawn(forward_track(track, request));
             }
             Err(err) => {
                 debug!(%name, "rejecting unknown track: {err:#}");
@@ -329,21 +333,24 @@ pub(crate) async fn forward_broadcast(
     }
 }
 
-/// Copies one track's groups and frames from `upstream` to `downstream`.
+/// Copies one track's groups and frames from `upstream` into the requested track.
+///
+/// The downstream request's own preferences are carried upstream, and the request is
+/// only accepted once upstream resolves, so the accepted track reports the metadata
+/// the source actually has rather than a default. A failure to subscribe upstream
+/// rejects the request instead of accepting a track that can never produce.
 ///
 /// Upstream group sequences are preserved rather than re-numbered, so a subscriber
 /// still sees the publisher's ordering and any gaps it needs for skip decisions.
-async fn forward_track(
-    upstream: moq_lite::track::Consumer,
-    mut downstream: moq_lite::track::Producer,
-) {
-    let mut subscriber = match upstream.subscribe(None).await {
+async fn forward_track(upstream: moq_lite::track::Consumer, request: moq_lite::track::Request) {
+    let mut subscriber = match upstream.subscribe(request.subscription()).await {
         Ok(subscriber) => subscriber,
         Err(err) => {
-            let _ = downstream.abort(err);
+            request.reject(err);
             return;
         }
     };
+    let mut downstream = request.accept(subscriber.info().clone());
     let mut groups = JoinSet::new();
     let outcome = loop {
         // Reap finished copies so the set does not grow for the life of the track.
@@ -442,9 +449,7 @@ impl MoqSession {
             .with_publisher(publish_prod.consume())
             .with_subscriber(subscribe_prod);
         let (moq_session, driver) = client.connect(wt_session.clone()).await?;
-        let driver = AbortOnDropHandle::new(spawn(async move {
-            let _ = driver.await;
-        }));
+        let driver = AbortOnDropHandle::new(spawn(driver));
         Ok(Self {
             publish: publish_prod,
             subscribe,
@@ -469,9 +474,7 @@ impl MoqSession {
             .with_publisher(publish_prod.consume())
             .with_subscriber(subscribe_prod);
         let (moq_session, driver) = server.accept(wt_session.clone()).await?;
-        let driver = AbortOnDropHandle::new(spawn(async move {
-            let _ = driver.await;
-        }));
+        let driver = AbortOnDropHandle::new(spawn(driver));
         Ok(Self {
             publish: publish_prod,
             subscribe,
@@ -508,17 +511,18 @@ impl MoqSession {
     }
 
     /// Publishes a broadcast on this session, making it available to the remote peer.
-    pub fn publish(&self, name: impl ToString, broadcast: BroadcastConsumer) {
+    pub fn publish(
+        &self,
+        name: impl ToString,
+        broadcast: BroadcastConsumer,
+    ) -> Result<(), moq_lite::Error> {
         let name = name.to_string();
-        match announce_broadcast(&self.publish, &name, broadcast) {
-            Ok(handle) => {
-                self.forwards
-                    .lock()
-                    .expect("forwards poisoned")
-                    .insert(name, handle);
-            }
-            Err(err) => warn!(%name, "failed to announce broadcast: {err:#}"),
-        }
+        let announcement = announce_broadcast(&self.publish, &name, broadcast)?;
+        self.forwards
+            .lock()
+            .expect("forwards poisoned")
+            .insert(name, announcement);
+        Ok(())
     }
 
     /// Returns the origin producer for advanced publish operations.
@@ -658,7 +662,9 @@ impl Actor {
     fn handle_session(&mut self, session: MoqSession) {
         let remote = session.remote_id();
         for (name, producer) in self.publishing.iter() {
-            session.publish(name.as_str(), producer.consume());
+            if let Err(err) = session.publish(name.as_str(), producer.consume()) {
+                warn!(%name, "failed to announce broadcast to new session: {err:#}");
+            }
         }
         self.sessions.insert(remote, session.clone());
         // Notify incoming session subscribers (best-effort, ok if no receivers).
@@ -687,7 +693,9 @@ impl Actor {
 
     fn handle_publish_broadcast(&mut self, name: BroadcastName, producer: BroadcastProducer) {
         for session in self.sessions.values_mut() {
-            session.publish(name.clone(), producer.consume());
+            if let Err(err) = session.publish(name.clone(), producer.consume()) {
+                warn!(%name, "failed to announce broadcast to session: {err:#}");
+            }
         }
         let consume = producer.consume();
         let closed_name = name.clone();

--- a/iroh-moq/src/lib.rs
+++ b/iroh-moq/src/lib.rs
@@ -15,16 +15,21 @@ use iroh::{
     endpoint::{ConnectError, Connection, ConnectionError, WriteError},
     protocol::{AcceptError, ProtocolHandler},
 };
-use moq_lite::{BroadcastConsumer, BroadcastProducer, Origin, OriginConsumer, OriginProducer};
+use moq_lite::{
+    Origin,
+    broadcast::{Consumer as BroadcastConsumer, Producer as BroadcastProducer},
+    origin::{Consumer as OriginConsumer, Producer as OriginProducer},
+};
 use n0_error::{AnyError, Result, StdResultExt, anyerr, e, stack_error};
+pub use n0_future::task::AbortOnDropHandle;
 use n0_future::{
     FuturesUnordered, StreamExt,
     boxed::BoxFuture,
-    task::{AbortOnDropHandle, JoinSet, spawn},
+    task::{JoinSet, spawn},
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error_span, field, info, instrument};
+use tracing::{Instrument, debug, error_span, field, info, instrument, warn};
 use web_transport_iroh::SessionError;
 
 /// The ALPN protocol identifier for MoQ-lite connections.
@@ -259,8 +264,143 @@ impl IncomingSession {
 pub struct MoqSession {
     wt_session: web_transport_iroh::Session,
     _moq_session: Arc<moq_lite::Session>,
+    _driver: Arc<AbortOnDropHandle<()>>,
+    forwards: Forwards,
     publish: OriginProducer,
     subscribe: OriginConsumer,
+}
+
+/// Live forwarders for the broadcasts this session announces, keyed by name.
+///
+/// Dropping a handle aborts its forwarder, which finishes the announced broadcast.
+type Forwards = Arc<std::sync::Mutex<HashMap<String, AbortOnDropHandle<()>>>>;
+
+/// Announces `upstream` on `origin` under `name` and serves it in the background.
+///
+/// The returned handle owns the forwarding task: drop it to stop serving and finish
+/// the announced broadcast.
+///
+/// This replaces moq-lite 0.1's `origin::Producer::publish_broadcast(name, consumer)`.
+/// See [`forward_broadcast`] for why the work is needed at all.
+pub fn announce_broadcast(
+    origin: &OriginProducer,
+    name: &str,
+    upstream: BroadcastConsumer,
+) -> Result<AbortOnDropHandle<()>, moq_lite::Error> {
+    let announced = origin.create_broadcast(name, moq_lite::broadcast::Route::announced())?;
+    Ok(AbortOnDropHandle::new(spawn(forward_broadcast(
+        announced, upstream,
+    ))))
+}
+
+/// Announces `upstream` to the remote peer under `name` and serves it.
+///
+/// moq-lite 0.1 had `origin::Producer::publish_broadcast(name, consumer)`, which
+/// installed an existing consumer under a name and announced it in one step. 0.2
+/// inverted the ownership: `create_broadcast` mints a producer the origin owns, and
+/// there is no public way to hand an existing consumer to an announced path. So we
+/// create the announced broadcast and forward into it ourselves — the same shape
+/// moq-net's own subscriber uses when it re-serves a remote broadcast locally.
+///
+/// The announcement is the part that matters. A peer's subscriber only builds its
+/// local source when an announcement arrives, so a dynamically served (unannounced)
+/// broadcast is never reachable across a session, however correct it looks locally.
+pub(crate) async fn forward_broadcast(
+    // Held for the task's lifetime: dropping the producer finishes the broadcast.
+    announced: moq_lite::broadcast::Producer,
+    upstream: BroadcastConsumer,
+) {
+    let mut dynamic = announced.dynamic();
+    let mut tracks = JoinSet::new();
+    while let Ok(request) = dynamic.requested_track().await {
+        // Reap finished track forwarders; a long-lived broadcast can serve many.
+        while tracks.try_join_next().is_some() {}
+
+        let name = request.name().to_string();
+        match upstream.track(&name) {
+            Ok(track) => {
+                tracks.spawn(forward_track(track, request.accept(None)));
+            }
+            Err(err) => {
+                debug!(%name, "rejecting unknown track: {err:#}");
+                request.reject(err);
+            }
+        }
+    }
+}
+
+/// Copies one track's groups and frames from `upstream` to `downstream`.
+///
+/// Upstream group sequences are preserved rather than re-numbered, so a subscriber
+/// still sees the publisher's ordering and any gaps it needs for skip decisions.
+async fn forward_track(
+    upstream: moq_lite::track::Consumer,
+    mut downstream: moq_lite::track::Producer,
+) {
+    let mut subscriber = match upstream.subscribe(None).await {
+        Ok(subscriber) => subscriber,
+        Err(err) => {
+            let _ = downstream.abort(err);
+            return;
+        }
+    };
+    let mut groups = JoinSet::new();
+    let outcome = loop {
+        // Reap finished copies so the set does not grow for the life of the track.
+        while groups.try_join_next().is_some() {}
+
+        match subscriber.next_group().await {
+            Ok(Some(group)) => {
+                let sequence = group.sequence;
+                match downstream.create_group(moq_lite::group::Info { sequence }) {
+                    Ok(out) => {
+                        groups.spawn(forward_group(group, out));
+                    }
+                    Err(err) => break Err(err),
+                }
+            }
+            Ok(None) => break Ok(()),
+            Err(err) => break Err(err),
+        }
+    };
+
+    // Let the frames already in flight land before closing the track: dropping the
+    // JoinSet aborts its tasks, which would truncate the groups still being copied.
+    while groups.join_next().await.is_some() {}
+
+    match outcome {
+        Ok(()) => {
+            let _ = downstream.finish();
+        }
+        Err(err) => {
+            let _ = downstream.abort(err);
+        }
+    }
+}
+
+/// Copies one group's frames, preserving each frame's timestamp.
+async fn forward_group(
+    mut upstream: moq_lite::group::Consumer,
+    mut downstream: moq_lite::group::Producer,
+) {
+    loop {
+        match upstream.read_frame().await {
+            Ok(Some(frame)) => {
+                if let Err(err) = downstream.write_frame(frame.timestamp, frame.payload) {
+                    let _ = downstream.abort(err);
+                    return;
+                }
+            }
+            Ok(None) => {
+                let _ = downstream.finish();
+                return;
+            }
+            Err(err) => {
+                let _ = downstream.abort(err);
+                return;
+            }
+        }
+    }
 }
 
 impl fmt::Debug for MoqSession {
@@ -295,18 +435,23 @@ impl MoqSession {
         wt_session: web_transport_iroh::Session,
         origin: Origin,
     ) -> Result<Self, Error> {
-        let publish_prod = OriginProducer::new(origin);
-        let subscribe_prod = OriginProducer::new(origin);
+        let publish_prod = origin.produce();
+        let subscribe_prod = origin.produce();
         let subscribe = subscribe_prod.consume();
         let client = moq_lite::Client::new()
-            .with_publish(publish_prod.consume())
-            .with_consume(subscribe_prod);
-        let moq_session = client.connect(wt_session.clone()).await?;
+            .with_publisher(publish_prod.consume())
+            .with_subscriber(subscribe_prod);
+        let (moq_session, driver) = client.connect(wt_session.clone()).await?;
+        let driver = AbortOnDropHandle::new(spawn(async move {
+            let _ = driver.await;
+        }));
         Ok(Self {
             publish: publish_prod,
             subscribe,
             wt_session,
             _moq_session: Arc::new(moq_session),
+            _driver: Arc::new(driver),
+            forwards: Forwards::default(),
         })
     }
 
@@ -317,18 +462,23 @@ impl MoqSession {
         wt_session: web_transport_iroh::Session,
         origin: Origin,
     ) -> Result<Self, Error> {
-        let publish_prod = OriginProducer::new(origin);
-        let subscribe_prod = OriginProducer::new(origin);
+        let publish_prod = origin.produce();
+        let subscribe_prod = origin.produce();
         let subscribe = subscribe_prod.consume();
         let server = moq_lite::Server::new()
-            .with_publish(publish_prod.consume())
-            .with_consume(subscribe_prod);
-        let moq_session = server.accept(wt_session.clone()).await?;
+            .with_publisher(publish_prod.consume())
+            .with_subscriber(subscribe_prod);
+        let (moq_session, driver) = server.accept(wt_session.clone()).await?;
+        let driver = AbortOnDropHandle::new(spawn(async move {
+            let _ = driver.await;
+        }));
         Ok(Self {
             publish: publish_prod,
             subscribe,
             wt_session,
             _moq_session: Arc::new(moq_session),
+            _driver: Arc::new(driver),
+            forwards: Forwards::default(),
         })
     }
 
@@ -359,7 +509,16 @@ impl MoqSession {
 
     /// Publishes a broadcast on this session, making it available to the remote peer.
     pub fn publish(&self, name: impl ToString, broadcast: BroadcastConsumer) {
-        self.publish.publish_broadcast(name.to_string(), broadcast);
+        let name = name.to_string();
+        match announce_broadcast(&self.publish, &name, broadcast) {
+            Ok(handle) => {
+                self.forwards
+                    .lock()
+                    .expect("forwards poisoned")
+                    .insert(name, handle);
+            }
+            Err(err) => warn!(%name, "failed to announce broadcast: {err:#}"),
+        }
     }
 
     /// Returns the origin producer for advanced publish operations.
@@ -528,9 +687,7 @@ impl Actor {
 
     fn handle_publish_broadcast(&mut self, name: BroadcastName, producer: BroadcastProducer) {
         for session in self.sessions.values_mut() {
-            session
-                .publish
-                .publish_broadcast(name.clone(), producer.consume());
+            session.publish(name.clone(), producer.consume());
         }
         let consume = producer.consume();
         let closed_name = name.clone();

--- a/moq-media/Cargo.toml
+++ b/moq-media/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.100"
 derive_more = { version = "2.0.1", features = ["display", "debug", "eq", "deref"] }
-cpal = "0.18.1"
+cpal = "0.18.2"
 fixed-resample = { version = "0.9", features = ["resampler"] }
 ringbuf = "0.4"
 hang = { workspace = true }

--- a/moq-media/src/catalog.rs
+++ b/moq-media/src/catalog.rs
@@ -26,12 +26,28 @@ pub struct IrohLiveExt {
 
 impl CatalogExt for IrohLiveExt {}
 
+/// Catalog reference to a chat track: the name to subscribe to, and the
+/// priority to subscribe at.
+///
+/// moq-lite 0.1's `Track` filled this role, carrying `{ name, priority }` and
+/// deriving serde. 0.2 splits the two apart — the name is an argument to
+/// `create_track`, and `track::Info` holds the rest with no name and no serde —
+/// so the serialized shape lives here now. The JSON is unchanged, which matters:
+/// `IrohLiveExt` is flattened into the root catalog, and the browser client
+/// validates this section against an object schema whether or not it subscribes.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatTrack {
+    pub name: String,
+    pub priority: u8,
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Chat {
-    pub message: Option<moq_lite::Track>,
-    pub typing: Option<moq_lite::Track>,
+    pub message: Option<ChatTrack>,
+    pub typing: Option<ChatTrack>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -52,7 +68,7 @@ mod tests {
     fn ext_flattens_into_catalog() {
         let mut catalog = Catalog::default();
         catalog.ext.chat = Some(Chat {
-            message: Some(moq_lite::Track {
+            message: Some(ChatTrack {
                 name: "chat".to_string(),
                 priority: 10,
             }),

--- a/moq-media/src/chat.rs
+++ b/moq-media/src/chat.rs
@@ -11,9 +11,7 @@
 use std::time::Instant;
 
 use bytes::Bytes;
-use moq_lite::track::{
-    Consumer as TrackConsumer, Producer as TrackProducer, Subscriber, Subscription,
-};
+use moq_lite::track::{Producer as TrackProducer, Subscriber};
 
 use crate::catalog::ChatTrack;
 use tracing::{debug, warn};
@@ -69,10 +67,7 @@ impl ChatPublisher {
         }
         // Chat has no media timeline; every message is its own group.
         self.track
-            .write_frame(
-                moq_lite::Timestamp::from_millis(0).expect("zero is in range"),
-                Bytes::from(text),
-            )
+            .write_frame(moq_lite::Timestamp::ZERO, Bytes::from(text))
             .map_err(|e| anyhow::anyhow!("chat send failed: {e}"))?;
         Ok(())
     }
@@ -85,44 +80,21 @@ impl ChatPublisher {
 #[derive(derive_more::Debug)]
 pub struct ChatSubscriber {
     #[debug(skip)]
-    track: TrackConsumer,
-    priority: u8,
-    /// Opened on the first [`recv`](Self::recv). 0.2 made subscribing async, and
-    /// this type is handed out from a sync constructor, so it happens lazily.
-    #[debug(skip)]
-    subscriber: Option<Subscriber>,
+    subscriber: Subscriber,
 }
 
 impl ChatSubscriber {
-    /// Creates a new chat subscriber from a track consumer.
-    pub fn new(track: TrackConsumer, priority: u8) -> Self {
-        Self {
-            track,
-            priority,
-            subscriber: None,
-        }
+    /// Creates a new chat subscriber from an established track subscription.
+    pub fn new(subscriber: Subscriber) -> Self {
+        Self { subscriber }
     }
 
     /// Waits for the next chat message.
     ///
     /// Returns `None` when the track ends (peer left or broadcast closed).
     pub async fn recv(&mut self) -> Option<ChatMessage> {
-        if self.subscriber.is_none() {
-            match self
-                .track
-                .subscribe(Subscription::default().with_priority(self.priority))
-                .await
-            {
-                Ok(subscriber) => self.subscriber = Some(subscriber),
-                Err(e) => {
-                    warn!("chat subscribe failed: {e:#}");
-                    return None;
-                }
-            }
-        }
-        let subscriber = self.subscriber.as_mut().expect("subscribed above");
         loop {
-            let group = match subscriber.next_group().await {
+            let group = match self.subscriber.next_group().await {
                 Ok(Some(g)) => g,
                 Ok(None) => {
                     debug!("chat track ended");
@@ -173,10 +145,10 @@ mod tests {
                 moq_lite::track::Info::default().with_priority(track_info.priority),
             )
             .unwrap();
-        let consumer = producer.consume();
+        let subscription = producer.subscribe(None);
 
         let mut publisher = ChatPublisher::new(producer);
-        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
+        let mut subscriber = ChatSubscriber::new(subscription);
 
         publisher.send("hello").unwrap();
         publisher.send("world").unwrap();
@@ -198,10 +170,10 @@ mod tests {
                 moq_lite::track::Info::default().with_priority(track_info.priority),
             )
             .unwrap();
-        let consumer = producer.consume();
+        let subscription = producer.subscribe(None);
 
         let mut publisher = ChatPublisher::new(producer);
-        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
+        let mut subscriber = ChatSubscriber::new(subscription);
 
         publisher.send("").unwrap();
         publisher.send("after empty").unwrap();
@@ -220,9 +192,9 @@ mod tests {
                 moq_lite::track::Info::default().with_priority(track_info.priority),
             )
             .unwrap();
-        let consumer = producer.consume();
+        let subscription = producer.subscribe(None);
 
-        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
+        let mut subscriber = ChatSubscriber::new(subscription);
         producer.finish().unwrap();
 
         let result = subscriber.recv().await;

--- a/moq-media/src/chat.rs
+++ b/moq-media/src/chat.rs
@@ -11,7 +11,11 @@
 use std::time::Instant;
 
 use bytes::Bytes;
-use moq_lite::{Track, TrackConsumer, TrackProducer};
+use moq_lite::track::{
+    Consumer as TrackConsumer, Producer as TrackProducer, Subscriber, Subscription,
+};
+
+use crate::catalog::ChatTrack;
 use tracing::{debug, warn};
 
 /// Default track name for chat messages in the hang catalog.
@@ -21,9 +25,9 @@ pub const CHAT_TRACK_NAME: &str = "chat";
 /// but higher than catalog (100).
 pub const CHAT_PRIORITY: u8 = 10;
 
-/// Returns the [`Track`] descriptor for the chat message track.
-pub fn chat_track() -> Track {
-    Track {
+/// Returns the catalog descriptor for the chat message track.
+pub fn chat_track() -> ChatTrack {
+    ChatTrack {
         name: CHAT_TRACK_NAME.to_string(),
         priority: CHAT_PRIORITY,
     }
@@ -63,8 +67,12 @@ impl ChatPublisher {
         if text.is_empty() {
             return Ok(());
         }
+        // Chat has no media timeline; every message is its own group.
         self.track
-            .write_frame(Bytes::from(text))
+            .write_frame(
+                moq_lite::Timestamp::from_millis(0).expect("zero is in range"),
+                Bytes::from(text),
+            )
             .map_err(|e| anyhow::anyhow!("chat send failed: {e}"))?;
         Ok(())
     }
@@ -78,20 +86,43 @@ impl ChatPublisher {
 pub struct ChatSubscriber {
     #[debug(skip)]
     track: TrackConsumer,
+    priority: u8,
+    /// Opened on the first [`recv`](Self::recv). 0.2 made subscribing async, and
+    /// this type is handed out from a sync constructor, so it happens lazily.
+    #[debug(skip)]
+    subscriber: Option<Subscriber>,
 }
 
 impl ChatSubscriber {
     /// Creates a new chat subscriber from a track consumer.
-    pub fn new(track: TrackConsumer) -> Self {
-        Self { track }
+    pub fn new(track: TrackConsumer, priority: u8) -> Self {
+        Self {
+            track,
+            priority,
+            subscriber: None,
+        }
     }
 
     /// Waits for the next chat message.
     ///
     /// Returns `None` when the track ends (peer left or broadcast closed).
     pub async fn recv(&mut self) -> Option<ChatMessage> {
+        if self.subscriber.is_none() {
+            match self
+                .track
+                .subscribe(Subscription::default().with_priority(self.priority))
+                .await
+            {
+                Ok(subscriber) => self.subscriber = Some(subscriber),
+                Err(e) => {
+                    warn!("chat subscribe failed: {e:#}");
+                    return None;
+                }
+            }
+        }
+        let subscriber = self.subscriber.as_mut().expect("subscribed above");
         loop {
-            let group = match self.track.next_group().await {
+            let group = match subscriber.next_group().await {
                 Ok(Some(g)) => g,
                 Ok(None) => {
                     debug!("chat track ended");
@@ -105,7 +136,7 @@ impl ChatSubscriber {
 
             let mut consumer = group;
             match consumer.read_frame().await {
-                Ok(Some(data)) => match String::from_utf8(data.to_vec()) {
+                Ok(Some(data)) => match String::from_utf8(data.payload.to_vec()) {
                     Ok(text) if !text.is_empty() => {
                         return Some(ChatMessage {
                             text,
@@ -135,11 +166,17 @@ mod tests {
     #[tokio::test]
     async fn roundtrip() {
         let track_info = chat_track();
-        let producer = TrackProducer::new(track_info.clone());
+        let mut broadcast = moq_lite::broadcast::Info::default().produce();
+        let producer = broadcast
+            .create_track(
+                track_info.name.clone(),
+                moq_lite::track::Info::default().with_priority(track_info.priority),
+            )
+            .unwrap();
         let consumer = producer.consume();
 
         let mut publisher = ChatPublisher::new(producer);
-        let mut subscriber = ChatSubscriber::new(consumer);
+        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
 
         publisher.send("hello").unwrap();
         publisher.send("world").unwrap();
@@ -154,11 +191,17 @@ mod tests {
     #[tokio::test]
     async fn empty_messages_skipped() {
         let track_info = chat_track();
-        let producer = TrackProducer::new(track_info.clone());
+        let mut broadcast = moq_lite::broadcast::Info::default().produce();
+        let producer = broadcast
+            .create_track(
+                track_info.name.clone(),
+                moq_lite::track::Info::default().with_priority(track_info.priority),
+            )
+            .unwrap();
         let consumer = producer.consume();
 
         let mut publisher = ChatPublisher::new(producer);
-        let mut subscriber = ChatSubscriber::new(consumer);
+        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
 
         publisher.send("").unwrap();
         publisher.send("after empty").unwrap();
@@ -170,10 +213,16 @@ mod tests {
     #[tokio::test]
     async fn closed_track_returns_none() {
         let track_info = chat_track();
-        let mut producer = TrackProducer::new(track_info.clone());
+        let mut broadcast = moq_lite::broadcast::Info::default().produce();
+        let mut producer = broadcast
+            .create_track(
+                track_info.name.clone(),
+                moq_lite::track::Info::default().with_priority(track_info.priority),
+            )
+            .unwrap();
         let consumer = producer.consume();
 
-        let mut subscriber = ChatSubscriber::new(consumer);
+        let mut subscriber = ChatSubscriber::new(consumer, track_info.priority);
         producer.finish().unwrap();
 
         let result = subscriber.recv().await;

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -103,13 +103,16 @@ struct ActiveVideoPipeline {
     #[debug(skip)]
     _pipeline: VideoPipeline,
     #[debug(skip)]
-    track: TrackProducer,
+    track: Option<TrackProducer>,
 }
 
 impl Drop for ActiveVideoPipeline {
     fn drop(&mut self) {
-        // `abort` consumes the producer and Drop only has `&mut self`; Producer is Clone.
-        self.track.clone().abort(moq_lite::Error::Cancel).ok();
+        // `abort` consumes the producer, so take it out rather than cloning to
+        // satisfy Drop's `&mut self`.
+        if let Some(track) = self.track.take() {
+            track.abort(moq_lite::Error::Cancel).ok();
+        }
     }
 }
 
@@ -236,14 +239,14 @@ pub struct LocalBroadcast {
 #[derive(derive_more::Debug)]
 struct BroadcastGuard {
     #[debug(skip)]
-    producer: Mutex<BroadcastProducer>,
+    producer: BroadcastProducer,
     #[debug(skip)]
     _task: AbortOnDropHandle<()>,
 }
 
 impl Drop for BroadcastGuard {
     fn drop(&mut self) {
-        self.producer.lock().expect("poisoned").finish();
+        self.producer.finish();
     }
 }
 
@@ -280,7 +283,7 @@ impl LocalBroadcast {
             producer: producer.clone(),
             state,
             _guard: Arc::new(BroadcastGuard {
-                producer: Mutex::new(producer),
+                producer,
                 _task: AbortOnDropHandle::new(task_handle),
             }),
             stats,
@@ -374,16 +377,21 @@ impl LocalBroadcast {
                 }
             };
             let name = track.name().to_string();
-            // 0.2 hands back a request; accepting it yields the producer that
-            // `requested_track` used to return directly.
-            let track = track.accept(None);
-            if state
-                .lock()
-                .unwrap()
+            // 0.2 hands back a request to accept or reject. Decide before accepting:
+            // an accepted track we cannot serve would just be dropped on the peer.
+            let mut guard = state.lock().unwrap();
+            if !guard.serves(&name) {
+                info!("ignoring track request {name}: rendition not available");
+                track.reject(moq_lite::Error::NotFound);
+                continue;
+            }
+            let track = track.accept(guard.catalog.track_info());
+            let started = guard
                 .start_track(track.clone())
                 .inspect_err(|err| warn!(%name, "failed to start requested track: {err:#}"))
-                .is_ok()
-            {
+                .is_ok();
+            drop(guard);
+            if started {
                 info!("started track: {name}");
                 tokio::spawn({
                     let state = state.clone();
@@ -395,6 +403,8 @@ impl LocalBroadcast {
                         state.lock().expect("poisoned").stop_track(&name);
                     }
                 });
+            } else {
+                let _ = track.abort(moq_lite::Error::Cancel);
             }
         }
     }
@@ -451,8 +461,12 @@ impl LocalBroadcast {
                         .map(|t| (t.name.clone(), t.config.clone()))
                         .collect(),
                 };
+                // `Video` is #[non_exhaustive], so build it through `insert` rather
+                // than a struct literal; it also rejects duplicate rendition names.
                 let mut video = Video::default();
-                video.renditions = configs;
+                for (name, config) in configs {
+                    video.insert(&name, config).anyerr()?;
+                }
                 // Tear down existing video, install new input, then publish catalog.
                 // Order matters: the input must be available before the catalog is
                 // published, otherwise subscribers may request tracks we can't serve.
@@ -474,7 +488,9 @@ impl LocalBroadcast {
             Some(renditions) => {
                 let configs = renditions.available_renditions()?;
                 let mut audio = Audio::default();
-                audio.renditions = configs;
+                for (name, config) in configs {
+                    audio.insert(&name, config).anyerr()?;
+                }
                 state.remove_audio();
                 state.audio = Some(renditions);
                 state.catalog.set_audio(audio)?;
@@ -606,6 +622,11 @@ impl Drop for LocalBroadcast {
 pub struct CatalogProducer(#[debug(skip)] moq_mux::catalog::Producer<crate::catalog::IrohLiveExt>);
 
 impl CatalogProducer {
+    /// Track properties for a media track under this catalog.
+    pub fn track_info(&self) -> moq_lite::track::Info {
+        self.0.track_info()
+    }
+
     pub fn new(broadcast: &mut BroadcastProducer) -> Result<Self> {
         let mut producer =
             moq_mux::catalog::Producer::with_catalog(broadcast, Catalog::default()).anyerr()?;
@@ -684,6 +705,21 @@ impl State {
         self.video = None;
     }
 
+    /// Whether a rendition by this name can be served, checked before accepting a
+    /// request so an unknown name is rejected rather than accepted and then dropped.
+    fn serves(&self, name: &str) -> bool {
+        let video = match self.video.as_ref() {
+            Some(VideoInput::Renditions(renditions)) => renditions.contains_rendition(name),
+            Some(VideoInput::PreEncoded(tracks)) => tracks.iter().any(|t| t.name == name),
+            None => false,
+        };
+        video
+            || self
+                .audio
+                .as_ref()
+                .is_some_and(|audio| audio.contains_rendition(name))
+    }
+
     fn start_track(&mut self, track: moq_lite::track::Producer) -> Result<()> {
         let name = track.name().to_string();
 
@@ -696,7 +732,7 @@ impl State {
                     name,
                     ActiveVideoPipeline {
                         _pipeline: VideoPipeline::Encoder(pipeline),
-                        track,
+                        track: Some(track),
                     },
                 );
                 return Ok(());
@@ -710,7 +746,7 @@ impl State {
                         name,
                         ActiveVideoPipeline {
                             _pipeline: VideoPipeline::PreEncoded(pipeline),
-                            track,
+                            track: Some(track),
                         },
                     );
                     return Ok(());

--- a/moq-media/src/publish.rs
+++ b/moq-media/src/publish.rs
@@ -23,7 +23,10 @@ pub use controller::{
     StreamKind,
 };
 use hang::catalog::{Audio, AudioConfig, Video, VideoConfig};
-use moq_lite::{Broadcast, BroadcastProducer, TrackProducer};
+use moq_lite::{
+    broadcast::{Info as Broadcast, Producer as BroadcastProducer},
+    track::Producer as TrackProducer,
+};
 use n0_error::{Result, StdResultExt};
 use n0_future::task::AbortOnDropHandle;
 use tokio::sync::watch;
@@ -105,7 +108,8 @@ struct ActiveVideoPipeline {
 
 impl Drop for ActiveVideoPipeline {
     fn drop(&mut self) {
-        self.track.abort(moq_lite::Error::Cancel).ok();
+        // `abort` consumes the producer and Drop only has `&mut self`; Producer is Clone.
+        self.track.clone().abort(moq_lite::Error::Cancel).ok();
     }
 }
 
@@ -189,7 +193,7 @@ struct VideoRenditionEntry {
     factory: MakeVideoEncoder,
 }
 
-/// Creates a subscribe-side preview from any [`BroadcastConsumer`](moq_lite::BroadcastConsumer).
+/// Creates a subscribe-side preview from any [`BroadcastConsumer`](moq_lite::broadcast::Consumer).
 ///
 /// Subscribes to the consumer's catalog, spawns decoders, and returns media
 /// tracks suitable for rendering. This is the building block for previewing
@@ -198,7 +202,7 @@ struct VideoRenditionEntry {
 /// Re-exported from [`crate::subscribe::subscribe_preview_from_consumer`] for
 /// backwards compatibility. Prefer calling the subscribe module directly.
 pub async fn subscribe_preview_from_consumer<D: crate::traits::Decoders>(
-    consumer: moq_lite::BroadcastConsumer,
+    consumer: moq_lite::broadcast::Consumer,
     audio_backend: &dyn crate::traits::AudioStreamFactory,
     config: crate::format::PlaybackConfig,
 ) -> Result<crate::subscribe::MediaTracks> {
@@ -218,8 +222,29 @@ pub struct LocalBroadcast {
     #[debug(skip)]
     state: Arc<Mutex<State>>,
     #[debug(skip)]
-    _task: Arc<AbortOnDropHandle<()>>,
+    _guard: Arc<BroadcastGuard>,
     stats: crate::stats::PublishStats,
+}
+
+/// Closes the broadcast once the last [`LocalBroadcast`] clone goes away.
+///
+/// moq-lite 0.2 expects a producer to be finished explicitly — dropping one warns
+/// and leaves the broadcast open for any other live handle, and the dynamic handler
+/// counts as one. Holding both here means the last clone finishes the producer and
+/// only then drops the handler, so subscribers see the close rather than a broadcast
+/// left open by a handle nobody owns any more.
+#[derive(derive_more::Debug)]
+struct BroadcastGuard {
+    #[debug(skip)]
+    producer: Mutex<BroadcastProducer>,
+    #[debug(skip)]
+    _task: AbortOnDropHandle<()>,
+}
+
+impl Drop for BroadcastGuard {
+    fn drop(&mut self) {
+        self.producer.lock().expect("poisoned").finish();
+    }
 }
 
 impl Default for LocalBroadcast {
@@ -252,9 +277,12 @@ impl LocalBroadcast {
         let task_handle = tokio::spawn(Self::run_dynamic(state.clone(), dynamic));
 
         Self {
-            producer,
+            producer: producer.clone(),
             state,
-            _task: Arc::new(AbortOnDropHandle::new(task_handle)),
+            _guard: Arc::new(BroadcastGuard {
+                producer: Mutex::new(producer),
+                _task: AbortOnDropHandle::new(task_handle),
+            }),
             stats,
         }
     }
@@ -299,7 +327,13 @@ impl LocalBroadcast {
     /// Can only be called once per broadcast. Subsequent calls return an error.
     pub fn enable_chat(&mut self) -> Result<crate::chat::ChatPublisher> {
         let track_info = crate::chat::chat_track();
-        let track = self.producer.create_track(track_info.clone()).anyerr()?;
+        let track = self
+            .producer
+            .create_track(
+                track_info.name.clone(),
+                moq_lite::track::Info::default().with_priority(track_info.priority),
+            )
+            .anyerr()?;
         let publisher = crate::chat::ChatPublisher::new(track);
 
         let mut state = self.state.lock().expect("poisoned");
@@ -326,11 +360,11 @@ impl LocalBroadcast {
     }
 
     /// Returns a consumer that reads from this broadcast's producer.
-    pub fn consume(&self) -> moq_lite::BroadcastConsumer {
+    pub fn consume(&self) -> moq_lite::broadcast::Consumer {
         self.producer.consume()
     }
 
-    async fn run_dynamic(state: Arc<Mutex<State>>, mut dynamic: moq_lite::BroadcastDynamic) {
+    async fn run_dynamic(state: Arc<Mutex<State>>, mut dynamic: moq_lite::broadcast::Dynamic) {
         loop {
             let track = match dynamic.requested_track().await {
                 Ok(track) => track,
@@ -339,7 +373,10 @@ impl LocalBroadcast {
                     break;
                 }
             };
-            let name = track.name.clone();
+            let name = track.name().to_string();
+            // 0.2 hands back a request; accepting it yields the producer that
+            // `requested_track` used to return directly.
+            let track = track.accept(None);
             if state
                 .lock()
                 .unwrap()
@@ -414,12 +451,8 @@ impl LocalBroadcast {
                         .map(|t| (t.name.clone(), t.config.clone()))
                         .collect(),
                 };
-                let video = Video {
-                    renditions: configs,
-                    display: None,
-                    rotation: None,
-                    flip: None,
-                };
+                let mut video = Video::default();
+                video.renditions = configs;
                 // Tear down existing video, install new input, then publish catalog.
                 // Order matters: the input must be available before the catalog is
                 // published, otherwise subscribers may request tracks we can't serve.
@@ -440,9 +473,8 @@ impl LocalBroadcast {
         match renditions {
             Some(renditions) => {
                 let configs = renditions.available_renditions()?;
-                let audio = Audio {
-                    renditions: configs,
-                };
+                let mut audio = Audio::default();
+                audio.renditions = configs;
                 state.remove_audio();
                 state.audio = Some(renditions);
                 state.catalog.set_audio(audio)?;
@@ -652,8 +684,8 @@ impl State {
         self.video = None;
     }
 
-    fn start_track(&mut self, track: moq_lite::TrackProducer) -> Result<()> {
-        let name = track.name.clone();
+    fn start_track(&mut self, track: moq_lite::track::Producer) -> Result<()> {
+        let name = track.name().to_string();
 
         // Try video first.
         match self.video.as_mut() {
@@ -1419,9 +1451,11 @@ mod tests {
         let (w, h) = preset.dimensions();
         let source = TestVideoSource::new(w, h);
         let encoder = E::with_preset(preset).unwrap();
-        let track = moq_lite::Track::new("test-video");
-        let producer = TrackProducer::new(track);
-        let mut consumer = producer.consume();
+        let mut broadcast = Broadcast::default().produce();
+        let producer = broadcast
+            .create_track("test-video", moq_lite::track::Info::default())
+            .unwrap();
+        let mut consumer = producer.subscribe(None);
         let sink = MoqPacketSink::new(producer);
 
         let _pipeline = VideoEncoderPipeline::new(source, encoder, sink, Default::default());

--- a/moq-media/src/publish/controller.rs
+++ b/moq-media/src/publish/controller.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use moq_lite::BroadcastProducer;
+use moq_lite::broadcast::Producer as BroadcastProducer;
 use n0_error::{AnyError, Result};
 use n0_watcher::{Direct, Watchable};
 use tracing::info;

--- a/moq-media/src/subscribe.rs
+++ b/moq-media/src/subscribe.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use hang::catalog::{AudioConfig, VideoConfig};
-use moq_lite::{BroadcastConsumer, Track};
+use moq_lite::{broadcast::Consumer as BroadcastConsumer, track::Subscription};
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_future::task::AbortOnDropHandle;
 use n0_watcher::{Watchable, Watcher};
@@ -334,8 +334,11 @@ impl RemoteBroadcast {
 
         let (catalog_watchable, catalog_task) = {
             let track = broadcast
-                .subscribe_track(&hang::catalog::Catalog::default_track())
-                .std_context("missing catalog track")?;
+                .track(hang::catalog::Catalog::DEFAULT_NAME)
+                .std_context("missing catalog track")?
+                .subscribe(hang::catalog::Catalog::default_subscription())
+                .await
+                .std_context("failed to subscribe to catalog track")?;
             debug!("catalog track subscribed");
             let mut catalog_consumer = CatalogConsumer::new(track);
             let initial_catalog = catalog_consumer
@@ -461,8 +464,11 @@ impl RemoteBroadcast {
     /// Returns `None` if the catalog does not advertise a chat track.
     pub fn chat(&self) -> Option<crate::chat::ChatSubscriber> {
         let track_info = self.catalog().chat.as_ref()?.message.as_ref()?.clone();
-        let consumer = self.broadcast.subscribe_track(&track_info).ok()?;
-        Some(crate::chat::ChatSubscriber::new(consumer))
+        let consumer = self.broadcast.track(&track_info.name).ok()?;
+        Some(crate::chat::ChatSubscriber::new(
+            consumer,
+            track_info.priority,
+        ))
     }
 
     /// Returns the user metadata from the catalog, if set by the publisher.
@@ -520,17 +526,18 @@ impl RemoteBroadcast {
     }
 
     /// Subscribes to video with explicit config and a custom decoder.
-    pub fn video_with_decoder<D: VideoDecoder>(
+    pub async fn video_with_decoder<D: VideoDecoder>(
         &self,
         playback_config: &DecodeConfig,
         quality: Quality,
     ) -> Result<VideoTrack> {
         let track_name = self.catalog().select_video_rendition(quality)?;
         self.video_rendition::<D>(playback_config, &track_name)
+            .await
     }
 
     /// Subscribes to a specific video rendition with a custom decoder.
-    pub fn video_rendition<D: VideoDecoder>(
+    pub async fn video_rendition<D: VideoDecoder>(
         &self,
         playback_config: &DecodeConfig,
         track_name: &str,
@@ -549,10 +556,10 @@ impl RemoteBroadcast {
         );
         let track_consumer = self
             .broadcast
-            .subscribe_track(&Track {
-                name: track_name.to_string(),
-                priority: VIDEO_PRIORITY,
-            })
+            .track(track_name)
+            .anyerr()?
+            .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
+            .await
             .anyerr()?;
         tracing::debug!(track = track_name, "track subscription created");
         let consumer =
@@ -589,10 +596,10 @@ impl RemoteBroadcast {
         let config = audio.renditions.get(name).context("rendition not found")?;
         let track = self
             .broadcast
-            .subscribe_track(&Track {
-                name: name.to_string(),
-                priority: AUDIO_PRIORITY,
-            })
+            .track(name)
+            .anyerr()?
+            .subscribe(Subscription::default().with_priority(AUDIO_PRIORITY))
+            .await
             .anyerr()?;
         let consumer = OrderedConsumer::new(track, moq_mux::catalog::hang::Container::Legacy)
             .with_latency(max_latency);
@@ -611,8 +618,8 @@ impl RemoteBroadcast {
     /// Uses dynamic decoder dispatch based on the codec in the catalog.
     /// For explicit decoder selection, use [`video_with_decoder`](Self::video_with_decoder).
     #[cfg(any_video_codec)]
-    pub fn video(&self) -> Result<VideoTrack> {
-        self.video_with(Default::default())
+    pub async fn video(&self) -> Result<VideoTrack> {
+        self.video_with(Default::default()).await
     }
 
     /// Subscribes to the best-quality audio rendition.
@@ -626,14 +633,17 @@ impl RemoteBroadcast {
 
     /// Subscribes to video with options (non-generic, uses dynamic decoder dispatch).
     #[cfg(any_video_codec)]
-    pub fn video_with(&self, opts: VideoOptions) -> Result<VideoTrack> {
+    pub async fn video_with(&self, opts: VideoOptions) -> Result<VideoTrack> {
         use crate::codec::DynamicVideoDecoder;
         let decode_config = opts.decode_config();
         if let Some(rendition) = opts.target.as_ref().and_then(|t| t.rendition.as_ref()) {
-            return self.video_rendition::<DynamicVideoDecoder>(&decode_config, rendition);
+            return self
+                .video_rendition::<DynamicVideoDecoder>(&decode_config, rendition)
+                .await;
         }
         let quality = opts.resolve_quality();
         self.video_with_decoder::<DynamicVideoDecoder>(&decode_config, quality)
+            .await
     }
 
     /// Subscribes to audio with options (non-generic, uses dynamic decoder dispatch).
@@ -687,7 +697,7 @@ impl RemoteBroadcast {
     #[cfg(any_video_codec)]
     pub async fn video_ready(&self) -> Result<VideoTrack> {
         self.wait_for_video().await;
-        self.video()
+        self.video().await
     }
 
     /// Waits for audio renditions to appear, then subscribes to the best quality.
@@ -729,7 +739,7 @@ impl RemoteBroadcast {
     /// for reading encoded packets without decoding.
     ///
     /// Useful for recording or relaying encoded media directly.
-    pub fn raw_video_track(
+    pub async fn raw_video_track(
         &self,
         track_name: &str,
     ) -> Result<(MoqPacketSource, hang::catalog::VideoConfig)> {
@@ -742,10 +752,10 @@ impl RemoteBroadcast {
             .clone();
         let track_consumer = self
             .broadcast
-            .subscribe_track(&Track {
-                name: track_name.to_string(),
-                priority: VIDEO_PRIORITY,
-            })
+            .track(track_name)
+            .anyerr()?
+            .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
+            .await
             .anyerr()?;
         let consumer =
             OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
@@ -757,7 +767,7 @@ impl RemoteBroadcast {
     /// for reading encoded packets without decoding.
     ///
     /// Useful for recording or relaying encoded media directly.
-    pub fn raw_audio_track(
+    pub async fn raw_audio_track(
         &self,
         track_name: &str,
     ) -> Result<(MoqPacketSource, hang::catalog::AudioConfig)> {
@@ -770,10 +780,10 @@ impl RemoteBroadcast {
             .clone();
         let track_consumer = self
             .broadcast
-            .subscribe_track(&Track {
-                name: track_name.to_string(),
-                priority: AUDIO_PRIORITY,
-            })
+            .track(track_name)
+            .anyerr()?
+            .subscribe(Subscription::default().with_priority(AUDIO_PRIORITY))
+            .await
             .anyerr()?;
         let consumer =
             OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
@@ -1262,12 +1272,14 @@ impl MediaTracks {
             .catalog()
             .select_video_rendition(playback_config.quality)
             .ok();
-        let video = track_name.and_then(|name| {
-            broadcast
+        let video = match track_name {
+            Some(name) => broadcast
                 .video_rendition::<D::Video>(&playback_config.decode_config(), &name)
+                .await
                 .inspect_err(|err| tracing::warn!("no video track: {err}"))
-                .ok()
-        });
+                .ok(),
+            None => None,
+        };
         Ok(Self {
             broadcast,
             audio,
@@ -1352,7 +1364,9 @@ async fn adaptation_task_v2(
                     &decode_config,
                     &ranked[idx].name,
                     &frame_sender,
-                ) {
+                )
+                .await
+                {
                     Ok(handle) => {
                         current_idx = idx;
                         selected_rendition.set(ranked[idx].name.clone()).ok();
@@ -1412,7 +1426,9 @@ async fn adaptation_task_v2(
                     &decode_config,
                     &ranked[target_idx].name,
                     &frame_sender,
-                ) {
+                )
+                .await
+                {
                     Ok(handle) => {
                         current_idx = target_idx;
                         timers.last_switch_failure = None;
@@ -1438,7 +1454,9 @@ async fn adaptation_task_v2(
                     &decode_config,
                     &ranked[target_idx].name,
                     &frame_sender,
-                ) {
+                )
+                .await
+                {
                     Ok(handle) => {
                         current_idx = target_idx;
                         timers.last_switch_failure = None;
@@ -1471,7 +1489,9 @@ async fn adaptation_task_v2(
                     &decode_config,
                     &ranked[probe_idx].name,
                     &frame_sender,
-                ) {
+                )
+                .await
+                {
                     Ok(handle) => {
                         let baseline = sigs.congestion_events;
                         timers.probe_congestion_baseline = Some(baseline);
@@ -1494,7 +1514,7 @@ async fn adaptation_task_v2(
 
 /// Creates a new decoder pipeline that writes to the given frame sender.
 #[cfg(any_video_codec)]
-fn switch_rendition_v2(
+async fn switch_rendition_v2(
     broadcast: &RemoteBroadcast,
     decode_config: &DecodeConfig,
     rendition_name: &str,
@@ -1511,10 +1531,10 @@ fn switch_rendition_v2(
         .context("rendition not found")?;
     let track_consumer = broadcast
         .broadcast
-        .subscribe_track(&moq_lite::Track {
-            name: rendition_name.to_string(),
-            priority: VIDEO_PRIORITY,
-        })
+        .track(rendition_name)
+        .anyerr()?
+        .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
+        .await
         .anyerr()?;
     let consumer = OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
         .with_latency(max_latency);
@@ -1532,13 +1552,13 @@ fn switch_rendition_v2(
     )?)
 }
 
-/// Creates a subscribe-side preview from any [`BroadcastConsumer`](moq_lite::BroadcastConsumer).
+/// Creates a subscribe-side preview from any [`BroadcastConsumer`](moq_lite::broadcast::Consumer).
 ///
 /// Subscribes to the consumer's catalog, spawns decoders, and returns media
 /// tracks suitable for rendering. This is the building block for previewing
 /// both live capture and file import output.
 pub async fn subscribe_preview_from_consumer<D: Decoders>(
-    consumer: moq_lite::BroadcastConsumer,
+    consumer: moq_lite::broadcast::Consumer,
     audio_backend: &dyn crate::traits::AudioStreamFactory,
     config: crate::format::PlaybackConfig,
 ) -> Result<MediaTracks> {
@@ -1553,7 +1573,7 @@ pub async fn subscribe_preview_from_consumer<D: Decoders>(
 /// Non-generic convenience over [`subscribe_preview_from_consumer`] that uses
 /// [`DefaultDecoders`](crate::codec::DefaultDecoders).
 pub async fn subscribe_preview(
-    consumer: moq_lite::BroadcastConsumer,
+    consumer: moq_lite::broadcast::Consumer,
     audio_backend: &dyn crate::traits::AudioStreamFactory,
     config: crate::format::PlaybackConfig,
 ) -> Result<MediaTracks> {

--- a/moq-media/src/subscribe.rs
+++ b/moq-media/src/subscribe.rs
@@ -303,6 +303,30 @@ impl CatalogSnapshot {
     }
 }
 
+/// Subscribes to `name` at `priority` and wraps it in a latency-bounded container
+/// consumer — the shape every media track subscription needs.
+///
+/// Subscribing became a wire round-trip in moq-lite 0.2, so this is async; the
+/// catalog track is deliberately not routed through here, since hang provides its
+/// own subscription preferences for it.
+async fn subscribe_ordered(
+    broadcast: &BroadcastConsumer,
+    name: &str,
+    priority: u8,
+    max_latency: Duration,
+) -> Result<OrderedConsumer> {
+    let track = broadcast
+        .track(name)
+        .anyerr()?
+        .subscribe(Subscription::default().with_priority(priority))
+        .await
+        .anyerr()?;
+    Ok(
+        OrderedConsumer::new(track, moq_mux::catalog::hang::Container::Legacy)
+            .with_latency(max_latency),
+    )
+}
+
 impl RemoteBroadcast {
     /// Creates a new remote broadcast subscription with the default
     /// [`PlaybackPolicy`] (synced playout, 150 ms max latency).
@@ -461,14 +485,25 @@ impl RemoteBroadcast {
 
     /// Subscribes to the chat track and returns a [`ChatSubscriber`](crate::chat::ChatSubscriber).
     ///
-    /// Returns `None` if the catalog does not advertise a chat track.
-    pub fn chat(&self) -> Option<crate::chat::ChatSubscriber> {
-        let track_info = self.catalog().chat.as_ref()?.message.as_ref()?.clone();
-        let consumer = self.broadcast.track(&track_info.name).ok()?;
-        Some(crate::chat::ChatSubscriber::new(
-            consumer,
-            track_info.priority,
-        ))
+    /// Returns `Ok(None)` if the catalog does not advertise a chat track, and an
+    /// error if it does but the subscription fails.
+    pub async fn chat(&self) -> Result<Option<crate::chat::ChatSubscriber>> {
+        let Some(track_info) = self
+            .catalog()
+            .chat
+            .as_ref()
+            .and_then(|chat| chat.message.clone())
+        else {
+            return Ok(None);
+        };
+        let subscriber = self
+            .broadcast
+            .track(&track_info.name)
+            .anyerr()?
+            .subscribe(Subscription::default().with_priority(track_info.priority))
+            .await
+            .anyerr()?;
+        Ok(Some(crate::chat::ChatSubscriber::new(subscriber)))
     }
 
     /// Returns the user metadata from the catalog, if set by the publisher.
@@ -554,17 +589,9 @@ impl RemoteBroadcast {
             max_latency_ms = max_latency.as_millis(),
             "subscribing to video rendition"
         );
-        let track_consumer = self
-            .broadcast
-            .track(track_name)
-            .anyerr()?
-            .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
-            .await
-            .anyerr()?;
-        tracing::debug!(track = track_name, "track subscription created");
         let consumer =
-            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
-                .with_latency(max_latency);
+            subscribe_ordered(&self.broadcast, track_name, VIDEO_PRIORITY, max_latency).await?;
+        tracing::debug!(track = track_name, "track subscription created");
         VideoTrack::from_consumer::<D>(
             track_name.to_string(),
             consumer,
@@ -594,15 +621,8 @@ impl RemoteBroadcast {
         let catalog = self.catalog();
         let audio = &catalog.audio;
         let config = audio.renditions.get(name).context("rendition not found")?;
-        let track = self
-            .broadcast
-            .track(name)
-            .anyerr()?
-            .subscribe(Subscription::default().with_priority(AUDIO_PRIORITY))
-            .await
-            .anyerr()?;
-        let consumer = OrderedConsumer::new(track, moq_mux::catalog::hang::Container::Legacy)
-            .with_latency(max_latency);
+        let consumer =
+            subscribe_ordered(&self.broadcast, name, AUDIO_PRIORITY, max_latency).await?;
         AudioTrack::spawn::<D>(
             name.to_string(),
             consumer,
@@ -750,16 +770,13 @@ impl RemoteBroadcast {
             .get(track_name)
             .context("video rendition not found")?
             .clone();
-        let track_consumer = self
-            .broadcast
-            .track(track_name)
-            .anyerr()?
-            .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
-            .await
-            .anyerr()?;
-        let consumer =
-            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
-                .with_latency(self.playback_policy.max_latency);
+        let consumer = subscribe_ordered(
+            &self.broadcast,
+            track_name,
+            VIDEO_PRIORITY,
+            self.playback_policy.max_latency,
+        )
+        .await?;
         Ok((MoqPacketSource::new(consumer), config))
     }
 
@@ -778,16 +795,13 @@ impl RemoteBroadcast {
             .get(track_name)
             .context("audio rendition not found")?
             .clone();
-        let track_consumer = self
-            .broadcast
-            .track(track_name)
-            .anyerr()?
-            .subscribe(Subscription::default().with_priority(AUDIO_PRIORITY))
-            .await
-            .anyerr()?;
-        let consumer =
-            OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
-                .with_latency(self.playback_policy.max_latency);
+        let consumer = subscribe_ordered(
+            &self.broadcast,
+            track_name,
+            AUDIO_PRIORITY,
+            self.playback_policy.max_latency,
+        )
+        .await?;
         Ok((MoqPacketSource::new(consumer), config))
     }
 
@@ -1529,15 +1543,13 @@ async fn switch_rendition_v2(
         .renditions
         .get(rendition_name)
         .context("rendition not found")?;
-    let track_consumer = broadcast
-        .broadcast
-        .track(rendition_name)
-        .anyerr()?
-        .subscribe(Subscription::default().with_priority(VIDEO_PRIORITY))
-        .await
-        .anyerr()?;
-    let consumer = OrderedConsumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
-        .with_latency(max_latency);
+    let consumer = subscribe_ordered(
+        &broadcast.broadcast,
+        rendition_name,
+        VIDEO_PRIORITY,
+        max_latency,
+    )
+    .await?;
     let source = MoqPacketSource::new(consumer);
     let config: rusty_codecs::config::VideoConfig = config.clone().into();
     let sender = frame_sender.clone();

--- a/moq-media/src/transport.rs
+++ b/moq-media/src/transport.rs
@@ -1,7 +1,7 @@
 use std::{fmt, future::Future, time::Duration};
 
 use anyhow::Result;
-use moq_lite::{Timescale, TrackProducer};
+use moq_lite::{Timestamp, track::Producer as TrackProducer};
 use tokio::sync::mpsc;
 use tracing::trace;
 
@@ -107,7 +107,10 @@ impl fmt::Debug for MoqPacketSink {
 impl PacketSink for MoqPacketSink {
     fn write(&mut self, packet: EncodedFrame) -> Result<()> {
         let frame = moq_mux::container::Frame {
-            timestamp: Timescale::from_millis_unchecked(packet.timestamp.as_millis() as u64),
+            timestamp: Timestamp::from_millis(packet.timestamp.as_millis() as u64)
+                .map_err(|err| anyhow::anyhow!("frame timestamp out of range: {err}"))?,
+            // The encoder pipeline has no per-sample duration; only CMAF carries one.
+            duration: None,
             payload: packet.payload,
             keyframe: packet.is_keyframe,
         };

--- a/moq-media/tests/pipeline_integration.rs
+++ b/moq-media/tests/pipeline_integration.rs
@@ -29,7 +29,7 @@ const TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Creates a broadcast and consumer pair. The consumer is immediately usable
 /// because `LocalBroadcast::new()` registers its dynamic producer synchronously.
-fn setup_broadcast() -> (LocalBroadcast, moq_lite::BroadcastConsumer) {
+fn setup_broadcast() -> (LocalBroadcast, moq_lite::broadcast::Consumer) {
     let broadcast = LocalBroadcast::new();
     let consumer = broadcast.consume();
     (broadcast, consumer)
@@ -151,6 +151,7 @@ async fn multiple_renditions_subscriber_selects_each() {
     for name in &renditions {
         let mut track = remote
             .video_rendition::<moq_media::codec::DynamicVideoDecoder>(&Default::default(), name)
+            .await
             .unwrap();
         let frame = tokio::time::timeout(TIMEOUT, track.next_frame())
             .await
@@ -199,6 +200,7 @@ async fn multiple_renditions_have_distinct_dimensions() {
     for name in &renditions {
         let mut track = remote
             .video_rendition::<moq_media::codec::DynamicVideoDecoder>(&Default::default(), name)
+            .await
             .unwrap();
         let mut dims = Vec::new();
         for _ in 0..3 {

--- a/rusty-capture/src/platform/linux/pipewire.rs
+++ b/rusty-capture/src/platform/linux/pipewire.rs
@@ -566,7 +566,7 @@ fn buffer_to_frame(
     if spa_format == SpaVideoFormat::BGRx.as_raw() {
         // BGRx → BGRA with A=255.
         let mut buf = copy_rows(data, w, h, s, 4);
-        for pixel in buf.chunks_exact_mut(4) {
+        for pixel in buf.as_chunks_mut::<4>().0 {
             pixel[3] = 255;
         }
         return Some(VideoFrame::new_packed(
@@ -590,7 +590,7 @@ fn buffer_to_frame(
 
     if spa_format == SpaVideoFormat::RGBx.as_raw() {
         let mut packed = copy_rows(data, w, h, s, 4);
-        for pixel in packed.chunks_exact_mut(4) {
+        for pixel in packed.as_chunks_mut::<4>().0 {
             pixel[3] = 255;
         }
         return Some(VideoFrame::new_rgba(

--- a/rusty-capture/src/platform/linux/v4l2.rs
+++ b/rusty-capture/src/platform/linux/v4l2.rs
@@ -517,7 +517,12 @@ fn yuyv_to_rgba(data: &[u8], width: u32, height: u32) -> Vec<u8> {
 fn rgb_to_rgba(data: &[u8], width: u32, height: u32) -> Vec<u8> {
     let pixel_count = (width * height) as usize;
     let mut rgba = vec![255u8; pixel_count * 4];
-    for (src, dst) in data.chunks_exact(3).zip(rgba.chunks_exact_mut(4)) {
+    for (src, dst) in data
+        .as_chunks::<3>()
+        .0
+        .iter()
+        .zip(rgba.as_chunks_mut::<4>().0)
+    {
         dst[0] = src[0];
         dst[1] = src[1];
         dst[2] = src[2];

--- a/rusty-capture/src/platform/linux/x11.rs
+++ b/rusty-capture/src/platform/linux/x11.rs
@@ -343,7 +343,12 @@ impl VideoSource for X11ScreenCapturer {
 
                 // Convert BGRX → RGBA.
                 let mut rgba = vec![0u8; state.buf_size];
-                for (src, dst) in shm_slice.chunks_exact(4).zip(rgba.chunks_exact_mut(4)) {
+                for (src, dst) in shm_slice
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .zip(rgba.as_chunks_mut::<4>().0)
+                {
                     dst[0] = src[2]; // R ← B
                     dst[1] = src[1]; // G ← G
                     dst[2] = src[0]; // B ← R

--- a/rusty-codecs/src/codec/opus/decoder.rs
+++ b/rusty-codecs/src/codec/opus/decoder.rs
@@ -152,7 +152,7 @@ fn convert_channels_into(samples: &[f32], from_ch: u32, to_ch: u32, out: &mut Ve
             }
         }
         (2, 1) => {
-            for pair in samples.chunks_exact(2) {
+            for pair in samples.as_chunks::<2>().0 {
                 out.push((pair[0] + pair[1]) * 0.5);
             }
         }
@@ -338,7 +338,7 @@ mod tests {
         // 960 frames * 2 channels = 1920 interleaved samples
         assert_eq!(samples.len(), 960 * 2);
         // Each stereo pair should be identical (mono duplicated)
-        for pair in samples.chunks_exact(2) {
+        for pair in samples.as_chunks::<2>().0 {
             assert_eq!(
                 pair[0], pair[1],
                 "stereo pair should be equal for mono upmix"

--- a/rusty-codecs/src/codec/pcm/decoder.rs
+++ b/rusty-codecs/src/codec/pcm/decoder.rs
@@ -61,8 +61,10 @@ impl AudioDecoder for PcmAudioDecoder {
 
         // Deserialize little-endian f32 samples.
         let pcm: Vec<f32> = payload
-            .chunks_exact(4)
-            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes(*c))
             .collect();
 
         // Resample if needed.
@@ -121,7 +123,7 @@ fn convert_channels_into(samples: &[f32], from_ch: u32, to_ch: u32, out: &mut Ve
             }
         }
         (2, 1) => {
-            for pair in samples.chunks_exact(2) {
+            for pair in samples.as_chunks::<2>().0 {
                 out.push((pair[0] + pair[1]) * 0.5);
             }
         }
@@ -246,7 +248,7 @@ mod tests {
             .unwrap();
         let samples = dec.pop_samples().unwrap().unwrap();
         assert_eq!(samples.len(), 960 * 2);
-        for pair in samples.chunks_exact(2) {
+        for pair in samples.as_chunks::<2>().0 {
             assert_eq!(
                 pair[0], pair[1],
                 "stereo pair should be equal for mono upmix"

--- a/rusty-codecs/src/codec/pcm/encoder.rs
+++ b/rusty-codecs/src/codec/pcm/encoder.rs
@@ -220,8 +220,10 @@ mod tests {
         // Deserialize and compare to original.
         let decoded: Vec<f32> = pkt
             .payload
-            .chunks_exact(4)
-            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes(*c))
             .collect();
         assert_eq!(decoded.len(), sine.len());
         for (i, (&orig, &dec)) in sine.iter().zip(decoded.iter()).enumerate() {

--- a/rusty-codecs/src/codec/tests/harness.rs
+++ b/rusty-codecs/src/codec/tests/harness.rs
@@ -998,7 +998,7 @@ fn audio_pipeline_mono_encode_stereo_decode() {
 
         assert_eq!(decoded.len(), 96000);
 
-        for (i, pair) in decoded.chunks_exact(2).enumerate() {
+        for (i, pair) in decoded.as_chunks::<2>().0.iter().enumerate() {
             assert_eq!(
                 pair[0], pair[1],
                 "stereo pair at frame {i} should be equal: L={}, R={}",

--- a/rusty-codecs/src/config.rs
+++ b/rusty-codecs/src/config.rs
@@ -167,8 +167,8 @@ mod hang_interop {
                 description: h.description,
                 coded_width: h.coded_width,
                 coded_height: h.coded_height,
-                display_ratio_width: h.display_ratio_width,
-                display_ratio_height: h.display_ratio_height,
+                display_ratio_width: h.display_aspect_width,
+                display_ratio_height: h.display_aspect_height,
                 bitrate: h.bitrate,
                 framerate: h.framerate,
                 optimize_for_latency: h.optimize_for_latency,
@@ -182,13 +182,12 @@ mod hang_interop {
             config.description = c.description;
             config.coded_width = c.coded_width;
             config.coded_height = c.coded_height;
-            config.display_ratio_width = c.display_ratio_width;
-            config.display_ratio_height = c.display_ratio_height;
+            config.display_aspect_width = c.display_ratio_width;
+            config.display_aspect_height = c.display_ratio_height;
             config.bitrate = c.bitrate;
             config.framerate = c.framerate;
             config.optimize_for_latency = c.optimize_for_latency;
             config.container = Default::default();
-            config.jitter = None;
             config
         }
     }

--- a/rusty-codecs/src/format.rs
+++ b/rusty-codecs/src/format.rs
@@ -261,7 +261,12 @@ impl AppleGpuFrame {
             for y in 0..h {
                 let src = std::slice::from_raw_parts(base.add(y * stride), row_bytes);
                 let dst = &mut rgba[y * row_bytes..(y + 1) * row_bytes];
-                for (s, d) in src.chunks_exact(4).zip(dst.chunks_exact_mut(4)) {
+                for (s, d) in src
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .zip(dst.as_chunks_mut::<4>().0)
+                {
                     d[0] = s[2]; // R ← B
                     d[1] = s[1]; // G
                     d[2] = s[0]; // B ← R
@@ -759,7 +764,7 @@ impl VideoFrame {
                     data,
                 } => {
                     let mut rgba = data.to_vec();
-                    for chunk in rgba.chunks_exact_mut(4) {
+                    for chunk in rgba.as_chunks_mut::<4>().0 {
                         chunk.swap(0, 2);
                     }
                     RgbaImage::from_raw(w, h, rgba)


### PR DESCRIPTION
Hi 👋🏼 , 

- I was recommended `iroh` from some P2P streaming-related work I'm considering (and just running some tests on). 
- I see it's been a few weeks since the project was updated, so I just am pushing some of these things for my own use locally, and thought `iroh-live` might be able to use it as a head start to get the project back up to speed :)
- This is primarily just a deps change PR - no real code changes done outside the scope of that
- Happy to make any adjustments (or abandon if it's unnecessary)

## Summary

Updates iroh and the MoQ stack to current crates.io releases.

| Crate | From | To |
|---|---|---|
| `moq-lite` (`moq-net`) | 0.1.11 | 0.2.14 |
| `moq-mux` | 0.5.5 | 0.9.9 |
| `hang` | 0.19.1 | 0.20.6 |
| `moq-native` | 0.17.1 | 0.19.13 |
| `moq-relay` | 0.12.2 | 0.14.12 |
| `web-transport-iroh` | 0.6.0 | 0.7.0 |
| `iroh` | 1.0.0 | 1.1.0 |
| `cpal` | 0.18.1 | 0.18.2 |
| `@moq/watch` | 0.2.8 | 0.5.2 |
| `@moq/publish` | 0.2.4 | 0.4.5 |

- The MoQ crates are locked to each other through `moq-net 0.2`, so they move in one commit.
- `iroh 1.1` is semver compatible and needs no source changes.
- `iroh-gossip`, `iroh-tickets` and `iroh-smol-kv` accept `iroh ^1` and are unchanged.
- Each commit compiles on its own.

## API changes

- **Model types moved into role modules.** `Broadcast`/`BroadcastProducer`/`BroadcastConsumer` became `broadcast::{Info, Producer, Consumer}`, same for `track`. Aliased imports keep call sites unchanged.
- **`connect()`/`accept()` return `(Session, Driver)`.** The driver has to be polled for the session lifetime, so `iroh-moq` spawns it with the session.
- **`origin::Producer::publish_broadcast` is gone.** The origin mints producers via `create_broadcast(path, Route)` instead of adopting an existing consumer. `iroh-moq` creates the announced broadcast and forwards into it; `iroh-live-relay`'s pull path uses the same helper.
  - The broadcast has to be announced. A peer's subscriber only builds its local source when an announcement arrives, so serving through the origin's dynamic handler alone compiles but is unreachable across a session.
- **`moq_mux::import::Stream` is gone,** split into `ContainerStream` (fmp4) and `TrackStream` (avc3). The CLI importer follows that split.
- **`hang 0.20` catalog changes:**
  - `VideoConfig::display_ratio_*` renamed to `display_aspect_*`, `jitter` dropped.
  - Its `Track` type no longer carries a name or derives serde, so `IrohLiveExt`'s chat entry uses a local DTO.
  - The serialized JSON is unchanged. The browser client validates that section of the catalog whether or not it subscribes to chat.
- **Subscribing to a track is async now.** Propagates to `RemoteBroadcast::{video, video_with, video_rendition, raw_video_track, raw_audio_track, chat}`. `MoqSession::publish` returns `Result`, since announcing can fail.

## Maintainer notes

### `moq-relay 0.14.12` does not build as published

- It declares `http-cache-reqwest = "1.0.0-alpha.6"` with `default-features = false, features = ["manager-moka", "url-standard"]`.
- In alpha.8 `reqwest-middleware` became an optional dependency, so that feature set no longer enables it:

```
error: either feature `reqwest-middleware` or `middlewest` must be enabled
error[E0432]: unresolved import `reqwest_middleware`
```

- Pinned to alpha.7 in `Cargo.lock` here.
- A future `cargo update` will select alpha.8 again. Fixing it upstream needs an upper bound or the feature adding.

### Publisher disconnect regression

Caught by `publisher_drop_closes_subscriber`.

- `moq-net 0.2` expects a producer to be finished explicitly, and the dynamic handler now counts as a live handle.
- Dropping `LocalBroadcast` stopped closing the broadcast, so subscribers never saw the disconnect.
- Fixed with a refcounted guard on the existing task handle.
- `LocalBroadcast` is `Clone`, so a plain `Drop` impl would close the broadcast as soon as the first clone went away.

## Verification

CI green on Linux, macOS, Playwright browser E2E, and the aarch64 zigbuild.

Locally on macOS 26 with Rust 1.98:

- `cargo check` across default, `--all-features`, `--no-default-features`
- `clippy --all-targets --all-features -- -D warnings`
- `fmt --check`
- 346 tests
- 3 Playwright specs. `@moq/hang 0.4` parses `hang 0.20`'s catalog, and browser to relay negotiates `moq-lite-05`

## Other commits

- [9388026](https://github.com/ra0x3/iroh-live/commit/9388026) `fix: satisfy newer-toolchain lints`: `moq-relay 0.14` puts the floor at Rust 1.95, and that clippy flags `chunks_exact` with a constant size. Pre-existing sites, but `-D warnings` fails without them.
- [ca2cf17](https://github.com/ra0x3/iroh-live/commit/ca2cf17) `build: commit the relay web lockfile`: CI runs `npm ci`, which needs a lockfile. It only worked because `build.rs` ran `npm install` first and created one.
- [752ad80](https://github.com/ra0x3/iroh-live/commit/752ad80) `ci: cancel superseded runs`: per workflow, per ref concurrency group. `Release` serialises instead of cancelling, since it replaces assets on the rolling release and a run killed mid upload leaves the binaries and `SHA256SUMS` out of sync.
- [503314b](https://github.com/ra0x3/iroh-live/commit/503314b) `docs: drop the stale patch.crates-io instruction`: that section was removed from `Cargo.toml` in April.
- [47b0cc7](https://github.com/ra0x3/iroh-live/commit/47b0cc7) `docs: correct the ALPN version in the docs`: four references still named `moq-lite-03`.
- [e12851b](https://github.com/ra0x3/iroh-live/commit/e12851b) `ci: correct the dioxus exclusion comments`: the comments said `moq-media-dioxus` is only checked weekly, but `--workspace` overrides `default-members` and every run already compiles it. Comment only. To fix the behaviour instead:
  - drop the weekly job as redundant, or
  - add `--exclude moq-media-dioxus` to the main jobs so the claim holds and pushes get faster.

The ALPN stays on `moq-lite-04`. `moq-net 0.2` prefers `moq-lite-05` and still advertises 04, so this works as is. Moving to 05 breaks direct iroh peers and belongs in its own PR.
